### PR TITLE
Refactor country notes to CountryManager

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -135,7 +135,7 @@ public class ParserUtil {
         requireNonNull(rawCountryCode);
         String trimmedCountryCode = rawCountryCode.trim();
         if (!CountryManager.isValidCountryCode(trimmedCountryCode)) {
-            throw new ParseException(CountryManager.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Country.MESSAGE_CONSTRAINTS);
         }
         return new Country(trimmedCountryCode);
     }

--- a/src/main/java/seedu/address/model/country/Country.java
+++ b/src/main/java/seedu/address/model/country/Country.java
@@ -1,13 +1,6 @@
 package seedu.address.model.country;
 
-import static java.util.Objects.requireNonNull;
-
-import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Locale;
-import java.util.Set;
-
-import seedu.address.model.note.Note;
 
 /**
  * A representation of a Country that can be identified by a 2-letter ISO3166 country-code or by its country
@@ -17,7 +10,6 @@ public class Country {
 
     private final String countryName;
     private final String countryCode;
-    private final Set<Note> countryNotes;
 
     /**
      * Initializes a Country by its countryCode.
@@ -27,37 +19,6 @@ public class Country {
     public Country(String countryCode) {
         this.countryCode = countryCode;
         this.countryName = new Locale("", countryCode).getDisplayName();
-        this.countryNotes = new LinkedHashSet<>();
-    }
-
-    /**
-     * Gets the list of country notes associated with this country.
-     *
-     * @return The list of country notes associated with this country.
-     */
-    public Set<Note> getCountryNotes() {
-        return Collections.unmodifiableSet(this.countryNotes);
-    }
-
-    /**
-     * Adds a country note for this country.
-     * Method is protected as it is not intended for use outside of this package.
-     *
-     * @param countryNote The country note to be added.
-     */
-    protected void addCountryNote(Note countryNote) {
-        requireNonNull(countryNote);
-        this.countryNotes.add(countryNote);
-    }
-
-    /**
-     * Checks whether given country note has been added for this country.
-     *
-     * @param countryNote The given country note.
-     * @return True if given country note has been added for this country, false otherwise.
-     */
-    protected boolean hasCountryNote(Note countryNote) {
-        return countryNotes.contains(countryNote);
     }
 
     /**

--- a/src/main/java/seedu/address/model/country/Country.java
+++ b/src/main/java/seedu/address/model/country/Country.java
@@ -8,6 +8,8 @@ import java.util.Locale;
  */
 public class Country {
 
+    public static final String MESSAGE_CONSTRAINTS = "Country code must be a valid 2-letter ISO3166 country code";
+
     private final String countryName;
     private final String countryCode;
 

--- a/src/main/java/seedu/address/model/country/CountryManager.java
+++ b/src/main/java/seedu/address/model/country/CountryManager.java
@@ -1,8 +1,10 @@
 package seedu.address.model.country;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import seedu.address.model.note.Note;
 
@@ -14,13 +16,13 @@ public class CountryManager {
     //TODO: Should include checking for 3-letter Country Code?
     public static final String MESSAGE_CONSTRAINTS = "Country code must be a valid 2-letter ISO3166 country code";
     private static final String[] COUNTRY_CODES = Locale.getISOCountries();
-    private final Map<String, Country> countryCodeMap;
+    private final Map<Country, Set<Note>> countryNotesMap;
 
     /**
      * Initializes a CountryManager with a Map that maps ISO3166 2-letter country codes to countries.
      */
     public CountryManager() {
-        countryCodeMap = initCountryCodeMap();
+        countryNotesMap = initCountryNotesMap();
     }
 
     /**
@@ -38,12 +40,12 @@ public class CountryManager {
         return false;
     }
 
-    private static Map<String, Country> initCountryCodeMap() {
-        Map<String, Country> countryCodeMap = new HashMap<>();
+    private static Map<Country, Set<Note>> initCountryNotesMap() {
+        Map<Country, Set<Note>> newCountryNotesMap = new LinkedHashMap<>();
         for (String countryCode : COUNTRY_CODES) {
-            countryCodeMap.put(countryCode, new Country(countryCode));
+            newCountryNotesMap.put(new Country(countryCode), new LinkedHashSet<>());
         }
-        return countryCodeMap;
+        return newCountryNotesMap;
     }
 
     /**
@@ -54,10 +56,11 @@ public class CountryManager {
      * @return Whether {@code country} contains {@code countryNote}.
      */
     public boolean hasCountryNote(Country country, Note countryNote) {
-        if (!isValidCountryCode(country.getCountryCode())) {
+        if (!countryNotesMap.containsKey(country)) {
             return false;
         }
-        return countryCodeMap.get(country.getCountryCode()).hasCountryNote(countryNote);
+
+        return countryNotesMap.get(country).contains(countryNote);
     }
 
     /**
@@ -67,22 +70,10 @@ public class CountryManager {
      * @param countryNote The country note to be added.
      */
     public void addCountryNote(Country country, Note countryNote) {
-        if (isValidCountryCode(country.getCountryCode())) {
-            countryCodeMap.get(country.getCountryCode()).addCountryNote(countryNote);
+        if (!countryNotesMap.containsKey(country)) {
+            return;
         }
-    }
 
-    /**
-     * Returns the country that is identified by the given country code.
-     *
-     * @param countryCode The ISO3166 2-letter country code of the particular country.
-     * @return The country that is identified by the given country code.
-     */
-    public Country getCountryFromCode(String countryCode) {
-        if (isValidCountryCode(countryCode)) {
-            return countryCodeMap.get(countryCode);
-        } else {
-            throw new NullPointerException();
-        }
+        countryNotesMap.get(country).add(countryNote);
     }
 }

--- a/src/main/java/seedu/address/model/country/CountryManager.java
+++ b/src/main/java/seedu/address/model/country/CountryManager.java
@@ -40,6 +40,11 @@ public class CountryManager {
         return false;
     }
 
+    /**
+     * Initializes mapping from country to its countryNotes.
+     *
+     * @return The Mapping from country to its countryNotes.
+     */
     private static Map<Country, Set<Note>> initCountryNotesMap() {
         Map<Country, Set<Note>> newCountryNotesMap = new LinkedHashMap<>();
         for (String countryCode : COUNTRY_CODES) {

--- a/src/main/java/seedu/address/model/country/CountryManager.java
+++ b/src/main/java/seedu/address/model/country/CountryManager.java
@@ -14,7 +14,6 @@ import seedu.address.model.note.Note;
 public class CountryManager {
 
     //TODO: Should include checking for 3-letter Country Code?
-    public static final String MESSAGE_CONSTRAINTS = "Country code must be a valid 2-letter ISO3166 country code";
     private static final String[] COUNTRY_CODES = Locale.getISOCountries();
     private final Map<Country, Set<Note>> countryNotesMap;
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedClient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedClient.java
@@ -116,7 +116,7 @@ class JsonAdaptedClient {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Country.class.getSimpleName()));
         }
         if (!CountryManager.isValidCountryCode(country)) {
-            throw new IllegalValueException(CountryManager.MESSAGE_CONSTRAINTS);
+            throw new IllegalValueException(Country.MESSAGE_CONSTRAINTS);
         }
         final Country modelCountry = new Country(country);
 

--- a/src/test/java/seedu/address/logic/parser/ClientAddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ClientAddCommandParserTest.java
@@ -43,7 +43,7 @@ import seedu.address.model.client.Client;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
-import seedu.address.model.country.CountryManager;
+import seedu.address.model.country.Country;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.ClientBuilder;
 
@@ -152,7 +152,7 @@ public class ClientAddCommandParserTest {
         // invalid country
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + INVALID_COUNTRY_DESC + TIMEZONE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                CountryManager.MESSAGE_CONSTRAINTS);
+                Country.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB

--- a/src/test/java/seedu/address/model/country/CountryManagerTest.java
+++ b/src/test/java/seedu/address/model/country/CountryManagerTest.java
@@ -1,9 +1,6 @@
 package seedu.address.model.country;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Locale;
@@ -35,9 +32,10 @@ public class CountryManagerTest {
     public void hasCountryNote_duplicateNote_returnTrue() {
         CountryManager countryManager = new CountryManager();
         for (String countryCode : COUNTRY_CODES) {
+            Country country = new Country(countryCode);
             NoteStub genericNote = new NoteStub("generic note");
-            countryManager.getCountryFromCode(countryCode).addCountryNote(genericNote);
-            assertTrue(countryManager.hasCountryNote(new Country(countryCode), genericNote));
+            countryManager.addCountryNote(country, genericNote);
+            assertTrue(countryManager.hasCountryNote(country, genericNote));
         }
     }
 
@@ -54,55 +52,12 @@ public class CountryManagerTest {
     public void addCountryNote_validNote_updatesCorrectly() {
         CountryManager countryManager = new CountryManager();
         for (String countryCode : COUNTRY_CODES) {
-            Country country = countryManager.getCountryFromCode(countryCode);
+            Country country = new Country(countryCode);
             NoteStub genericNote = new NoteStub("generic note");
-            assertFalse(country.hasCountryNote(genericNote));
+            assertFalse(countryManager.hasCountryNote(country, genericNote));
             countryManager.addCountryNote(new Country(countryCode), genericNote);
-            assertTrue(country.hasCountryNote(genericNote));
+            assertTrue(countryManager.hasCountryNote(country, genericNote));
         }
     }
 
-    @Test
-    public void getCountryFromCode_validCode_validCountry() {
-        CountryManager countryManager = new CountryManager();
-
-        for (String countryCode : COUNTRY_CODES) {
-            Country country = countryManager.getCountryFromCode(countryCode);
-            assertNotNull(country);
-        }
-    }
-
-    @Test
-    public void getCountryFromCode_multipleRefSameCountry_reflectChanges() {
-        CountryManager countryManager = new CountryManager();
-        for (String countryCode : COUNTRY_CODES) {
-            Country countryFirstRef = countryManager.getCountryFromCode(countryCode);
-            Country countrySecondRef = countryManager.getCountryFromCode(countryCode);
-
-            assertEquals(0, countryFirstRef.getCountryNotes().size());
-            assertEquals(0, countrySecondRef.getCountryNotes().size());
-
-            countryFirstRef.addCountryNote(new NoteStub("something1"));
-            assertEquals(1, countryFirstRef.getCountryNotes().size());
-            assertEquals(1, countrySecondRef.getCountryNotes().size());
-
-            countrySecondRef.addCountryNote(new NoteStub("something2"));
-            assertEquals(2, countryFirstRef.getCountryNotes().size());
-            assertEquals(2, countrySecondRef.getCountryNotes().size());
-
-            countryManager.addCountryNote(countryFirstRef, new NoteStub("something3"));
-            assertEquals(3, countryFirstRef.getCountryNotes().size());
-            assertEquals(3, countrySecondRef.getCountryNotes().size());
-        }
-    }
-
-    @Test
-    public void getCountryFromCode_invalidCode_throwsNullPointerException() {
-        CountryManager countryManager = new CountryManager();
-        assertThrows(NullPointerException.class, () -> countryManager.getCountryFromCode("1"));
-        assertThrows(NullPointerException.class, () -> countryManager.getCountryFromCode("12"));
-        assertThrows(NullPointerException.class, () -> countryManager.getCountryFromCode("123"));
-        assertThrows(NullPointerException.class, () -> countryManager.getCountryFromCode("ab"));
-        assertThrows(NullPointerException.class, () -> countryManager.getCountryFromCode("ZZ"));
-    }
 }

--- a/src/test/java/seedu/address/model/country/CountryTest.java
+++ b/src/test/java/seedu/address/model/country/CountryTest.java
@@ -1,94 +1,15 @@
 package seedu.address.model.country;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Locale;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
-
-import seedu.address.model.note.Note;
 
 public class CountryTest {
 
     private static final String[] COUNTRY_CODES = Locale.getISOCountries();
-
-    @Test
-    public void getCountryNotes_addValidNote_throwsUnsupportedOperationException() {
-        for (String countryCode : COUNTRY_CODES) {
-            Country country = new Country(countryCode);
-            Set<Note> countryNotes = country.getCountryNotes();
-            NoteStub genericNote = new NoteStub("something");
-            assertThrows(UnsupportedOperationException.class, () -> countryNotes.add(genericNote));
-        }
-    }
-
-    @Test
-    public void getCountryNotes_deleteNote_throwsUnsupportedOperationException() {
-        for (String countryCode : COUNTRY_CODES) {
-            Country country = new Country(countryCode);
-            NoteStub genericNote = new NoteStub("something");
-            country.addCountryNote(genericNote);
-            Set<Note> countryNotes = country.getCountryNotes();
-            assertThrows(UnsupportedOperationException.class, () -> countryNotes.remove(genericNote));
-        }
-    }
-
-    @Test
-    public void addCountryNotes_addValidNote_updatesCountryNotesList() {
-        for (String countryCode : COUNTRY_CODES) {
-            Country country = new Country(countryCode);
-            assertEquals(0, country.getCountryNotes().size());
-            NoteStub genericNote = new NoteStub("something");
-            country.addCountryNote(genericNote);
-            assertEquals(1, country.getCountryNotes().size());
-        }
-    }
-
-    @Test
-    public void addCountryNotes_nullNote_throwsNullPointerException() {
-        for (String countryCode : COUNTRY_CODES) {
-            Country country = new Country(countryCode);
-            assertThrows(NullPointerException.class, () -> {
-                NoteStub genericNote = null;
-                country.addCountryNote(genericNote);
-            });
-        }
-    }
-
-    @Test
-    public void hasCountryNote_noteExists_returnTrue() {
-        for (String countryCode : COUNTRY_CODES) {
-            Country country = new Country(countryCode);
-            NoteStub genericNote = new NoteStub("generic note");
-            country.addCountryNote(genericNote);
-            assertTrue(country.hasCountryNote(genericNote));
-        }
-    }
-
-    @Test
-    public void hasCountryNote_noteNotExists_returnFalse() {
-        for (String countryCode : COUNTRY_CODES) {
-            Country country = new Country(countryCode);
-            NoteStub genericNote = new NoteStub("generic note");
-            country.addCountryNote(genericNote);
-            NoteStub otherNote = new NoteStub("other note");
-            assertFalse(country.hasCountryNote(otherNote));
-        }
-    }
-
-    @Test
-    public void equals_sameObj_returnTrue() {
-        for (String countryCode : COUNTRY_CODES) {
-            Country countryFirst = new Country(countryCode);
-            Country countrySecond = new Country(countryCode);
-            assertEquals(countryFirst, countrySecond);
-        }
-    }
 
     @Test
     public void equals_notACountry_returnFalse() {

--- a/src/test/java/seedu/address/storage/JsonAdaptedClientTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedClientTest.java
@@ -17,7 +17,6 @@ import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
 import seedu.address.model.country.Country;
-import seedu.address.model.country.CountryManager;
 
 public class JsonAdaptedClientTest {
     private static final String INVALID_NAME = "R@chel";
@@ -112,7 +111,7 @@ public class JsonAdaptedClientTest {
     public void toModelType_invalidCountry_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                 INVALID_COUNTRY, VALID_TIMEZONE, VALID_TAGS);
-        String expectedMessage = CountryManager.MESSAGE_CONSTRAINTS;
+        String expectedMessage = Country.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 


### PR DESCRIPTION
## Description

Country Notes were stored previously in Country class.
I have refactored Country such that the country notes will be stored in CountryManager instead.

This would be a better design choice since we do not need to update Client every time a country note is added / deleted. Client can just store a Country that is basically a representation of the country code and country name.

On the UI side, country notes can be retrieved from the CountryManager given the specific country.

Fixes #130 

## Testing

Mainly fixed failing tests. No new tests were added.

## Remarks

NIL.
