### PR TITLE
Increase test coverage

### DIFF
--- a/src/test/java/seedu/address/AppParametersTest.java
+++ b/src/test/java/seedu/address/AppParametersTest.java
@@ -20,7 +20,7 @@ public class AppParametersTest {
     private final AppParameters expected = new AppParameters();
 
     @Test
-    public void getConfigPath_returnsCorrectConfigPath() {
+    public void getConfigPath_returnsSetConfigPath() {
         expected.setConfigPath(Paths.get("config.json"));
         assertEquals(expected.getConfigPath(), Paths.get("config.json"));
     }

--- a/src/test/java/seedu/address/AppParametersTest.java
+++ b/src/test/java/seedu/address/AppParametersTest.java
@@ -1,6 +1,8 @@
 package seedu.address;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Paths;
 import java.util.Collections;
@@ -16,6 +18,12 @@ public class AppParametersTest {
 
     private final ParametersStub parametersStub = new ParametersStub();
     private final AppParameters expected = new AppParameters();
+
+    @Test
+    public void getConfigPath_returnsCorrectConfigPath() {
+        expected.setConfigPath(Paths.get("config.json"));
+        assertEquals(expected.getConfigPath(), Paths.get("config.json"));
+    }
 
     @Test
     public void parse_validConfigPath_success() {
@@ -37,8 +45,24 @@ public class AppParametersTest {
         assertEquals(expected, AppParameters.parse(parametersStub));
     }
 
+    @Test
+    public void equals_sameConfigPath_returnsTrue() {
+        expected.setConfigPath(Paths.get("config.json"));
+        AppParameters other = new AppParameters();
+        other.setConfigPath(Paths.get("config.json"));
+        assertTrue(expected.equals(other));
+    }
+
+    @Test
+    public void equals_differentConfigPath_returnsFalse() {
+        expected.setConfigPath(Paths.get("config.json"));
+        AppParameters other = new AppParameters();
+        other.setConfigPath(Paths.get("config2.json"));
+        assertFalse(expected.equals(other));
+    }
+
     private static class ParametersStub extends Application.Parameters {
-        private Map<String, String> namedParameters = new HashMap<>();
+        private final Map<String, String> namedParameters = new HashMap<>();
 
         @Override
         public List<String> getRaw() {

--- a/src/test/java/seedu/address/commons/core/ConfigTest.java
+++ b/src/test/java/seedu/address/commons/core/ConfigTest.java
@@ -4,24 +4,39 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.nio.file.Paths;
+import java.util.logging.Level;
+
 import org.junit.jupiter.api.Test;
 
 public class ConfigTest {
+
+    private final Config defaultConfig = new Config();
+
+    @Test
+    public void getLogLevel_returnsSetLogLevel() {
+        defaultConfig.setLogLevel(Level.WARNING);
+        assertEquals(Level.WARNING, defaultConfig.getLogLevel());
+    }
+
+    @Test
+    public void getUserPrefsFilePath_returnsSetUserPrefsFilePath() {
+        defaultConfig.setUserPrefsFilePath(Paths.get("prefs.json"));
+        assertEquals(Paths.get("prefs.json"), defaultConfig.getUserPrefsFilePath());
+    }
 
     @Test
     public void toString_defaultObject_stringReturned() {
         String defaultConfigAsString = "Current log level : INFO\n"
                 + "Preference file Location : preferences.json";
 
-        assertEquals(defaultConfigAsString, new Config().toString());
+        assertEquals(defaultConfigAsString, defaultConfig.toString());
     }
 
     @Test
     public void equalsMethod() {
-        Config defaultConfig = new Config();
         assertNotNull(defaultConfig);
         assertTrue(defaultConfig.equals(defaultConfig));
     }
-
 
 }

--- a/src/test/java/seedu/address/commons/core/GuiSettingsTest.java
+++ b/src/test/java/seedu/address/commons/core/GuiSettingsTest.java
@@ -1,0 +1,45 @@
+package seedu.address.commons.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Point;
+
+import org.junit.jupiter.api.Test;
+
+public class GuiSettingsTest {
+
+    private final GuiSettings defaultGuiSettings = new GuiSettings();
+
+    @Test
+    public void constructor() {
+        double windowWidth = 200.0;
+        double windowHeight = 100.0;
+        int xPosition = 50;
+        int yPosition = 10;
+        Point windowCoordinates = new Point(xPosition, yPosition);
+        GuiSettings guiSettings = new GuiSettings(windowWidth, windowHeight, xPosition, yPosition);
+        assertEquals(guiSettings.getWindowWidth(), windowWidth);
+        assertEquals(guiSettings.getWindowHeight(), windowHeight);
+        assertEquals(guiSettings.getWindowCoordinates(), windowCoordinates);
+    }
+
+    @Test
+    public void toString_defaultObject_stringReturned() {
+        String defaultGuiSettingsAsString = "Width : 740.0\n"
+                + "Height : 600.0\n"
+                + "Position : null";
+        assertEquals(defaultGuiSettings.toString(), defaultGuiSettingsAsString);
+    }
+
+    @Test
+    public void equals() {
+        assertTrue(defaultGuiSettings.equals(new GuiSettings()));
+        assertFalse(defaultGuiSettings.equals(null));
+
+        GuiSettings guiSettings = new GuiSettings(1.0, 1.0, 5, 1);
+        assertTrue(guiSettings.equals(guiSettings));
+        assertFalse(defaultGuiSettings.equals(guiSettings));
+    }
+}

--- a/src/test/java/seedu/address/model/util/SampleDataUtilTest.java
+++ b/src/test/java/seedu/address/model/util/SampleDataUtilTest.java
@@ -1,0 +1,44 @@
+package seedu.address.model.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.model.util.SampleDataUtil.getSampleAddressBook;
+import static seedu.address.model.util.SampleDataUtil.getSampleClients;
+import static seedu.address.model.util.SampleDataUtil.getTagSet;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.client.Client;
+import seedu.address.model.tag.Tag;
+
+public class SampleDataUtilTest {
+
+    @Test
+    public void getSampleAddressBook_getSampleClients_containSameClients() {
+        ReadOnlyAddressBook addressBook = getSampleAddressBook();
+        Client[] sampleClientArray = getSampleClients();
+        ObservableList<Client> sampleClients = FXCollections.observableList(Arrays.asList(sampleClientArray));
+        assertEquals(sampleClients, addressBook.getClientList());
+    }
+
+    @Test
+    public void getTagSet_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> getTagSet((String) null));
+    }
+
+    @Test
+    public void getTagSet_tagStrings_returnsCorrectTags() {
+        Set<Tag> tags = new HashSet<>();
+        tags.add(new Tag("Tag1"));
+        tags.add(new Tag("Tag2"));
+        assertEquals(tags, getTagSet("Tag1", "Tag2"));
+    }
+
+}


### PR DESCRIPTION
## Description

As per title.

Fixes #160 

## Testing

The tests all pass.

## Remarks

Note that `assertTrue(...equals())` is used instead of `assertEquals` to be more explicit and ensure codecov detects the coverage.
