### PR TITLE
Add contract expiry field to client

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClientAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientAddCommand.java
@@ -38,7 +38,7 @@ public class ClientAddCommand extends Command {
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_COUNTRY + "SG "
             + PREFIX_TIMEZONE + "GMT+8 "
-            + PREFIX_CONTRACT_EXPIRY_DATE + "30/1/2023 "
+            + PREFIX_CONTRACT_EXPIRY_DATE + "30-1-2023 "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
 

--- a/src/main/java/seedu/address/logic/commands/ClientAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientAddCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTRACT_EXPIRY_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNTRY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -28,6 +29,7 @@ public class ClientAddCommand extends Command {
             + PREFIX_ADDRESS + "ADDRESS "
             + PREFIX_COUNTRY + "COUNTRY_CODE "
             + PREFIX_TIMEZONE + "TIMEZONE "
+            + PREFIX_CONTRACT_EXPIRY_DATE + "CONTRACT_EXPIRY_DATE "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
@@ -36,6 +38,7 @@ public class ClientAddCommand extends Command {
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_COUNTRY + "SG "
             + PREFIX_TIMEZONE + "GMT+8 "
+            + PREFIX_CONTRACT_EXPIRY_DATE + "30/1/2023 "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
 

--- a/src/main/java/seedu/address/logic/commands/ClientEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientEditCommand.java
@@ -23,7 +23,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
-import seedu.address.model.client.Date;
+import seedu.address.model.client.ContractExpiryDate;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -107,12 +107,12 @@ public class ClientEditCommand extends Command {
         Address updatedAddress = editClientDescriptor.getAddress().orElse(clientToEdit.getAddress());
         Country updatedCountry = editClientDescriptor.getCountry().orElse(clientToEdit.getCountry());
         Timezone updatedTimezone = editClientDescriptor.getTimezone().orElse(clientToEdit.getTimezone());
-        Date updatedContractExpiryDate =
+        ContractExpiryDate updatedContractExpiryContractExpiryDate =
                 editClientDescriptor.getContractExpiryDate().orElse(clientToEdit.getContractExpiryDate());
         Set<Tag> updatedTags = editClientDescriptor.getTags().orElse(clientToEdit.getTags());
 
         return new Client(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedCountry, updatedTimezone,
-                updatedContractExpiryDate, updatedTags);
+                updatedContractExpiryContractExpiryDate, updatedTags);
     }
 
     @Override
@@ -144,7 +144,7 @@ public class ClientEditCommand extends Command {
         private Address address;
         private Country country;
         private Timezone timezone;
-        private Date contractExpiryDate;
+        private ContractExpiryDate contractExpiryDate;
         private Set<Tag> tags;
 
         public EditClientDescriptor() {}
@@ -220,11 +220,11 @@ public class ClientEditCommand extends Command {
             return Optional.ofNullable(timezone);
         }
 
-        public void setContractExpiryDate(Date contractExpiryDate) {
+        public void setContractExpiryDate(ContractExpiryDate contractExpiryDate) {
             this.contractExpiryDate = contractExpiryDate;
         }
 
-        public Optional<Date> getContractExpiryDate() {
+        public Optional<ContractExpiryDate> getContractExpiryDate() {
             return Optional.ofNullable(contractExpiryDate);
         }
 

--- a/src/main/java/seedu/address/logic/commands/ClientEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientEditCommand.java
@@ -23,6 +23,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.Date;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -106,10 +107,12 @@ public class ClientEditCommand extends Command {
         Address updatedAddress = editClientDescriptor.getAddress().orElse(clientToEdit.getAddress());
         Country updatedCountry = editClientDescriptor.getCountry().orElse(clientToEdit.getCountry());
         Timezone updatedTimezone = editClientDescriptor.getTimezone().orElse(clientToEdit.getTimezone());
+        Date updatedContractExpiryDate =
+                editClientDescriptor.getContractExpiryDate().orElse(clientToEdit.getContractExpiryDate());
         Set<Tag> updatedTags = editClientDescriptor.getTags().orElse(clientToEdit.getTags());
 
         return new Client(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedCountry, updatedTimezone,
-                updatedTags);
+                updatedContractExpiryDate, updatedTags);
     }
 
     @Override
@@ -141,6 +144,7 @@ public class ClientEditCommand extends Command {
         private Address address;
         private Country country;
         private Timezone timezone;
+        private Date contractExpiryDate;
         private Set<Tag> tags;
 
         public EditClientDescriptor() {}
@@ -156,6 +160,7 @@ public class ClientEditCommand extends Command {
             setAddress(toCopy.address);
             setCountry(toCopy.country);
             setTimezone(toCopy.timezone);
+            setContractExpiryDate(toCopy.contractExpiryDate);
             setTags(toCopy.tags);
         }
 
@@ -163,7 +168,8 @@ public class ClientEditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, country, timezone, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, country, timezone,
+                    contractExpiryDate, tags);
         }
 
         public void setName(Name name) {
@@ -214,6 +220,14 @@ public class ClientEditCommand extends Command {
             return Optional.ofNullable(timezone);
         }
 
+        public void setContractExpiryDate(Date contractExpiryDate) {
+            this.contractExpiryDate = contractExpiryDate;
+        }
+
+        public Optional<Date> getContractExpiryDate() {
+            return Optional.ofNullable(contractExpiryDate);
+        }
+
         /**
          * Sets {@code tags} to this object's {@code tags}.
          * A defensive copy of {@code tags} is used internally.
@@ -252,6 +266,7 @@ public class ClientEditCommand extends Command {
                     && getAddress().equals(e.getAddress())
                     && getCountry().equals(e.getCountry())
                     && getTimezone().equals(e.getTimezone())
+                    && getContractExpiryDate().equals(e.getContractExpiryDate())
                     && getTags().equals(e.getTags());
         }
     }

--- a/src/main/java/seedu/address/logic/commands/ClientEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientEditCommand.java
@@ -107,12 +107,12 @@ public class ClientEditCommand extends Command {
         Address updatedAddress = editClientDescriptor.getAddress().orElse(clientToEdit.getAddress());
         Country updatedCountry = editClientDescriptor.getCountry().orElse(clientToEdit.getCountry());
         Timezone updatedTimezone = editClientDescriptor.getTimezone().orElse(clientToEdit.getTimezone());
-        ContractExpiryDate updatedContractExpiryContractExpiryDate =
+        ContractExpiryDate updatedContractExpiryDate =
                 editClientDescriptor.getContractExpiryDate().orElse(clientToEdit.getContractExpiryDate());
         Set<Tag> updatedTags = editClientDescriptor.getTags().orElse(clientToEdit.getTags());
 
         return new Client(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedCountry, updatedTimezone,
-                updatedContractExpiryContractExpiryDate, updatedTags);
+                updatedContractExpiryDate, updatedTags);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,6 +13,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_COUNTRY = new Prefix("c/");
     public static final Prefix PREFIX_TIMEZONE = new Prefix("tz/");
+    public static final Prefix PREFIX_CONTRACT_EXPIRY_DATE = new Prefix("ce/");
     public static final Prefix PREFIX_NOTE = new Prefix("nt/");
     public static final Prefix PREFIX_SUGGEST = new Prefix("by/");
 

--- a/src/main/java/seedu/address/logic/parser/ClientAddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClientAddCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTRACT_EXPIRY_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNTRY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -16,6 +17,7 @@ import seedu.address.logic.commands.ClientAddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.Date;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -36,10 +38,10 @@ public class ClientAddCommandParser implements Parser<ClientAddCommand> {
     public ClientAddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                        PREFIX_COUNTRY, PREFIX_TIMEZONE, PREFIX_TAG);
+                        PREFIX_COUNTRY, PREFIX_TIMEZONE, PREFIX_CONTRACT_EXPIRY_DATE, PREFIX_TAG);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_COUNTRY,
-                PREFIX_TIMEZONE) || !argMultimap.getPreamble().isEmpty()) {
+                PREFIX_TIMEZONE, PREFIX_CONTRACT_EXPIRY_DATE) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ClientAddCommand.MESSAGE_USAGE));
         }
 
@@ -49,9 +51,11 @@ public class ClientAddCommandParser implements Parser<ClientAddCommand> {
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Country country = ParserUtil.parseCountry(argMultimap.getValue(PREFIX_COUNTRY).get());
         Timezone timezone = ParserUtil.parseTimezone(argMultimap.getValue(PREFIX_TIMEZONE).get());
+        Date contractExpiryDate =
+                ParserUtil.parseContractExpiryDate(argMultimap.getValue(PREFIX_CONTRACT_EXPIRY_DATE).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Client client = new Client(name, phone, email, address, country, timezone, tagList);
+        Client client = new Client(name, phone, email, address, country, timezone, contractExpiryDate, tagList);
 
         return new ClientAddCommand(client);
     }

--- a/src/main/java/seedu/address/logic/parser/ClientAddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClientAddCommandParser.java
@@ -17,7 +17,7 @@ import seedu.address.logic.commands.ClientAddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
-import seedu.address.model.client.Date;
+import seedu.address.model.client.ContractExpiryDate;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -51,7 +51,7 @@ public class ClientAddCommandParser implements Parser<ClientAddCommand> {
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Country country = ParserUtil.parseCountry(argMultimap.getValue(PREFIX_COUNTRY).get());
         Timezone timezone = ParserUtil.parseTimezone(argMultimap.getValue(PREFIX_TIMEZONE).get());
-        Date contractExpiryDate =
+        ContractExpiryDate contractExpiryDate =
                 ParserUtil.parseContractExpiryDate(argMultimap.getValue(PREFIX_CONTRACT_EXPIRY_DATE).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 

--- a/src/main/java/seedu/address/logic/parser/ClientEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClientEditCommandParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTRACT_EXPIRY_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNTRY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -34,7 +35,7 @@ public class ClientEditCommandParser implements Parser<ClientEditCommand> {
     public ClientEditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                PREFIX_ADDRESS, PREFIX_COUNTRY, PREFIX_TIMEZONE, PREFIX_TAG);
+                PREFIX_ADDRESS, PREFIX_COUNTRY, PREFIX_TIMEZONE, PREFIX_CONTRACT_EXPIRY_DATE, PREFIX_TAG);
 
         Index index;
 
@@ -63,6 +64,10 @@ public class ClientEditCommandParser implements Parser<ClientEditCommand> {
         }
         if (argMultimap.getValue(PREFIX_TIMEZONE).isPresent()) {
             editClientDescriptor.setTimezone(ParserUtil.parseTimezone(argMultimap.getValue(PREFIX_TIMEZONE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_CONTRACT_EXPIRY_DATE).isPresent()) {
+            editClientDescriptor.setContractExpiryDate(
+                    ParserUtil.parseContractExpiryDate(argMultimap.getValue(PREFIX_CONTRACT_EXPIRY_DATE).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editClientDescriptor::setTags);
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -10,6 +11,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.client.Address;
+import seedu.address.model.client.Date;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -112,7 +114,6 @@ public class ParserUtil {
         return new Tag(trimmedTag);
     }
 
-
     /**
      * Parses {@code Collection<String> tags} into a {@code Set<Tag>}.
      */
@@ -200,5 +201,23 @@ public class ParserUtil {
             suggestionSet.add(parseSuggestionType(suggestionType));
         }
         return suggestionSet;
+    }
+
+    /**
+     * Parses a {@code String dateString} into a {@code Date}.
+     */
+    public static Date parseContractExpiryDate(String dateString) throws ParseException {
+        requireNonNull(dateString);
+        String trimmedDateString = dateString.trim();
+        if (!Date.isValidDate(trimmedDateString)) {
+            throw new ParseException(Date.MESSAGE_CONSTRAINTS);
+        }
+        LocalDate date;
+        try {
+            date = LocalDate.parse(trimmedDateString, Date.DATE_FORMATTER);
+        } catch (Exception e) {
+            throw new ParseException(Date.MESSAGE_CONSTRAINTS);
+        }
+        return new Date(date);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
-import java.time.LocalDate;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -212,12 +211,6 @@ public class ParserUtil {
         if (!ContractExpiryDate.isValidDate(trimmedDateString)) {
             throw new ParseException(ContractExpiryDate.MESSAGE_CONSTRAINTS);
         }
-        LocalDate date;
-        try {
-            date = LocalDate.parse(trimmedDateString, ContractExpiryDate.DATE_FORMATTER);
-        } catch (Exception e) {
-            throw new ParseException(ContractExpiryDate.MESSAGE_CONSTRAINTS);
-        }
-        return new ContractExpiryDate(date);
+        return new ContractExpiryDate(trimmedDateString);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -11,7 +11,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.client.Address;
-import seedu.address.model.client.Date;
+import seedu.address.model.client.ContractExpiryDate;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -204,20 +204,20 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a {@code String dateString} into a {@code Date}.
+     * Parses a {@code String dateString} into a {@code ContractExpiryDate}.
      */
-    public static Date parseContractExpiryDate(String dateString) throws ParseException {
+    public static ContractExpiryDate parseContractExpiryDate(String dateString) throws ParseException {
         requireNonNull(dateString);
         String trimmedDateString = dateString.trim();
-        if (!Date.isValidDate(trimmedDateString)) {
-            throw new ParseException(Date.MESSAGE_CONSTRAINTS);
+        if (!ContractExpiryDate.isValidDate(trimmedDateString)) {
+            throw new ParseException(ContractExpiryDate.MESSAGE_CONSTRAINTS);
         }
         LocalDate date;
         try {
-            date = LocalDate.parse(trimmedDateString, Date.DATE_FORMATTER);
+            date = LocalDate.parse(trimmedDateString, ContractExpiryDate.DATE_FORMATTER);
         } catch (Exception e) {
-            throw new ParseException(Date.MESSAGE_CONSTRAINTS);
+            throw new ParseException(ContractExpiryDate.MESSAGE_CONSTRAINTS);
         }
-        return new Date(date);
+        return new ContractExpiryDate(date);
     }
 }

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -180,7 +180,7 @@ public class Client {
                 .append(getCountry())
                 .append(" Timezone: ")
                 .append(getTimezone())
-                .append(" Contract Expiry ContractExpiryDate: ")
+                .append(" Contract Expiry Date: ")
                 .append(getContractExpiryDate())
                 .append(" Tags: ");
         getTags().forEach(builder::append);

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -28,7 +28,7 @@ public class Client {
     private final Address address;
     private final Country country;
     private final Timezone timezone;
-    private final Date contractExpiryDate;
+    private final ContractExpiryDate contractExpiryDate;
     private final Set<Tag> tags = new HashSet<>();
     private final Set<Note> clientNotes = new LinkedHashSet<>(); // todo: initialise this iff client has notes
 
@@ -36,7 +36,7 @@ public class Client {
      * Every field must be present and not null.
      */
     public Client(Name name, Phone phone, Email email, Address address, Country country, Timezone timezone,
-                  Date contractExpiryDate, Set<Tag> tags) {
+                  ContractExpiryDate contractExpiryDate, Set<Tag> tags) {
         requireAllNonNull(name, phone, email, address, tags);
         this.name = name;
         this.phone = phone;
@@ -72,7 +72,7 @@ public class Client {
         return timezone;
     }
 
-    public Date getContractExpiryDate() {
+    public ContractExpiryDate getContractExpiryDate() {
         return contractExpiryDate;
     }
 
@@ -180,7 +180,7 @@ public class Client {
                 .append(getCountry())
                 .append(" Timezone: ")
                 .append(getTimezone())
-                .append(" Contract Expiry Date: ")
+                .append(" Contract Expiry ContractExpiryDate: ")
                 .append(getContractExpiryDate())
                 .append(" Tags: ");
         getTags().forEach(builder::append);

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -28,6 +28,7 @@ public class Client {
     private final Address address;
     private final Country country;
     private final Timezone timezone;
+    private final Date contractExpiryDate;
     private final Set<Tag> tags = new HashSet<>();
     private final Set<Note> clientNotes = new LinkedHashSet<>(); // todo: initialise this iff client has notes
 
@@ -35,7 +36,7 @@ public class Client {
      * Every field must be present and not null.
      */
     public Client(Name name, Phone phone, Email email, Address address, Country country, Timezone timezone,
-                  Set<Tag> tags) {
+                  Date contractExpiryDate, Set<Tag> tags) {
         requireAllNonNull(name, phone, email, address, tags);
         this.name = name;
         this.phone = phone;
@@ -43,6 +44,7 @@ public class Client {
         this.address = address;
         this.country = country;
         this.timezone = timezone;
+        this.contractExpiryDate = contractExpiryDate;
         this.tags.addAll(tags);
     }
 
@@ -68,6 +70,10 @@ public class Client {
 
     public Timezone getTimezone() {
         return timezone;
+    }
+
+    public Date getContractExpiryDate() {
+        return contractExpiryDate;
     }
 
     /**
@@ -150,6 +156,7 @@ public class Client {
                 && otherClient.getAddress().equals(getAddress())
                 && otherClient.getCountry().equals(getCountry())
                 && otherClient.getTimezone().equals(getTimezone())
+                && otherClient.getContractExpiryDate().equals(getContractExpiryDate())
                 && otherClient.getTags().equals(getTags());
     }
 
@@ -173,6 +180,8 @@ public class Client {
                 .append(getCountry())
                 .append(" Timezone: ")
                 .append(getTimezone())
+                .append(" Contract Expiry Date: ")
+                .append(getContractExpiryDate())
                 .append(" Tags: ");
         getTags().forEach(builder::append);
         return builder.toString();

--- a/src/main/java/seedu/address/model/client/ContractExpiryDate.java
+++ b/src/main/java/seedu/address/model/client/ContractExpiryDate.java
@@ -6,15 +6,15 @@ import java.time.format.ResolverStyle;
 import java.util.Objects;
 
 /**
- * Represents a date.
+ * Represents a contract expiry date.
  * Guarantees: immutable; is valid as declared in {@link #isValidDate(String)}
  */
-public class Date implements Comparable<Date> {
+public class ContractExpiryDate implements Comparable<ContractExpiryDate> {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Date should be in the format day-month-year, where day is between 1 and 31 and month is between 1-12.";
+    public static final String MESSAGE_CONSTRAINTS = "ContractExpiryDate should be in the format day-month-year,"
+            + " where day is between 1 and 31 and month is between 1-12.";
     /*
-     * Date should be in the format day-month-year separating the digits.
+     * ContractExpiryDate should be in the format day-month-year separating the digits.
      * Day should be in the range 1-31, month should be in the range 1-12, and year can be from 0000-9999.
      */
     public static final String VALIDATION_REGEX =
@@ -29,7 +29,7 @@ public class Date implements Comparable<Date> {
     /**
      * Constructs a date object.
      */
-    public Date(LocalDate date) {
+    public ContractExpiryDate(LocalDate date) {
         this.date = date;
         this.value = date.format(DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT));
     }
@@ -45,8 +45,8 @@ public class Date implements Comparable<Date> {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof Date // instanceof handles nulls
-                && date.equals(((Date) other).date)); // state check
+                || (other instanceof ContractExpiryDate // instanceof handles nulls
+                && date.equals(((ContractExpiryDate) other).date)); // state check
     }
 
     @Override
@@ -60,7 +60,7 @@ public class Date implements Comparable<Date> {
     }
 
     @Override
-    public int compareTo(Date other) {
+    public int compareTo(ContractExpiryDate other) {
         return date.compareTo(other.date);
     }
 }

--- a/src/main/java/seedu/address/model/client/ContractExpiryDate.java
+++ b/src/main/java/seedu/address/model/client/ContractExpiryDate.java
@@ -1,5 +1,7 @@
 package seedu.address.model.client;
 
+import static java.util.Objects.requireNonNull;
+
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.ResolverStyle;
@@ -30,6 +32,7 @@ public class ContractExpiryDate implements Comparable<ContractExpiryDate> {
      * Constructs a date object.
      */
     public ContractExpiryDate(LocalDate date) {
+        requireNonNull(date);
         this.date = date;
         this.value = date.format(DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT));
     }

--- a/src/main/java/seedu/address/model/client/ContractExpiryDate.java
+++ b/src/main/java/seedu/address/model/client/ContractExpiryDate.java
@@ -1,6 +1,7 @@
 package seedu.address.model.client;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -31,18 +32,26 @@ public class ContractExpiryDate implements Comparable<ContractExpiryDate> {
     /**
      * Constructs a date object.
      */
-    public ContractExpiryDate(LocalDate date) {
+    public ContractExpiryDate(String date) {
         requireNonNull(date);
-        this.date = date;
-        this.value = date.format(DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT));
+        checkArgument(isValidDate(date), MESSAGE_CONSTRAINTS);
+        this.date = LocalDate.parse(date, DATE_FORMATTER);
+        this.value = this.date.format(DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT));
     }
 
     /**
-     * Returns true if the String follows the correct date format.
-     * This does not check for valid dates (e.g. 31st Feb will return true).
+     * Returns true if the String follows the correct date format and is a valid date.
      */
     public static boolean isValidDate(String test) {
-        return test.matches(VALIDATION_REGEX);
+        if (test.matches(VALIDATION_REGEX)) {
+            try {
+                LocalDate.parse(test, DATE_FORMATTER);
+                return true;
+            } catch (Exception e) {
+                return false;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/client/Date.java
+++ b/src/main/java/seedu/address/model/client/Date.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 public class Date implements Comparable<Date> {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Date should be in the format date-month-year";
+            "Date should be in the format day-month-year, where day is between 1 and 31 and month is between 1-12.";
     /*
      * Date should be in the format day-month-year separating the digits.
      * Day should be in the range 1-31, month should be in the range 1-12, and year can be from 0000-9999.
@@ -20,9 +20,9 @@ public class Date implements Comparable<Date> {
     public static final String VALIDATION_REGEX =
             "^([0]?[1-9]|[1|2][0-9]|[3][0|1])[-]([0]?[1-9]|[1][0-2])[-]([0-9]{4}|[0-9]{2})$";
 
-    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("d-M-u")
+    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("d-M-[uuuu][uu]")
             .withResolverStyle(ResolverStyle.STRICT);
-    public static final String DEFAULT_DATE_FORMAT = "d-M-u";
+    public static final String DEFAULT_DATE_FORMAT = "d-M-uuuu";
     public final String value;
     private final LocalDate date;
 
@@ -52,6 +52,11 @@ public class Date implements Comparable<Date> {
     @Override
     public int hashCode() {
         return Objects.hash(date);
+    }
+
+    @Override
+    public String toString() {
+        return value;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/client/Date.java
+++ b/src/main/java/seedu/address/model/client/Date.java
@@ -1,0 +1,61 @@
+package seedu.address.model.client;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
+import java.util.Objects;
+
+/**
+ * Represents a date.
+ * Guarantees: immutable; is valid as declared in {@link #isValidDate(String)}
+ */
+public class Date implements Comparable<Date> {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Date should be in the format date-month-year";
+    /*
+     * Date should be in the format day-month-year separating the digits.
+     * Day should be in the range 1-31, month should be in the range 1-12, and year can be from 0000-9999.
+     */
+    public static final String VALIDATION_REGEX =
+            "^([0]?[1-9]|[1|2][0-9]|[3][0|1])[-]([0]?[1-9]|[1][0-2])[-]([0-9]{4}|[0-9]{2})$";
+
+    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("d-M-u")
+            .withResolverStyle(ResolverStyle.STRICT);
+    public static final String DEFAULT_DATE_FORMAT = "d-M-u";
+    public final String value;
+    private final LocalDate date;
+
+    /**
+     * Constructs a date object.
+     */
+    public Date(LocalDate date) {
+        this.date = date;
+        this.value = date.format(DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT));
+    }
+
+    /**
+     * Returns true if the String follows the correct date format.
+     * This does not check for valid dates (e.g. 31st Feb will return true).
+     */
+    public static boolean isValidDate(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Date // instanceof handles nulls
+                && date.equals(((Date) other).date)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(date);
+    }
+
+    @Override
+    public int compareTo(Date other) {
+        return date.compareTo(other.date);
+    }
+}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -1,5 +1,6 @@
 package seedu.address.model.util;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Set;
@@ -10,6 +11,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.Date;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -27,23 +29,25 @@ public class SampleDataUtil {
         return new Client[]{
             new Client(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"), new Country("SG"), new Timezone("GMT+8"),
-                getTagSet("friends")),
+                new Date(LocalDate.of(2022, 4, 21)), getTagSet("friends")),
             new Client(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new Country("SG"),
-                new Timezone("GMT+8"), getTagSet("colleagues", "friends")),
+                new Timezone("GMT+8"), new Date(LocalDate.of(2021, 12, 12)),
+                getTagSet("colleagues", "friends")),
             new Client(new Name("Charlotte Oliveiro"), new Phone("93210283"),
                 new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new Country("SG"), new Timezone("GMT+8"),
-                getTagSet("neighbours")),
+                new Date(LocalDate.of(2023, 4, 1)), getTagSet("neighbours")),
             new Client(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new Country("SG"),
-                new Timezone("GMT+8"), getTagSet("family")),
+                new Timezone("GMT+8"), new Date(LocalDate.of(2020, 12, 23)),
+                getTagSet("family")),
             new Client(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"), new Country("SG"), new Timezone("GMT+8"),
-                getTagSet("classmates")),
+                new Date(LocalDate.of(2021, 2, 3)), getTagSet("classmates")),
             new Client(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"), new Country("SG"), new Timezone("GMT+8"),
-                getTagSet("colleagues"))
+                new Date(LocalDate.of(2024, 6, 9)), getTagSet("colleagues"))
         };
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -1,6 +1,5 @@
 package seedu.address.model.util;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Set;
@@ -29,25 +28,25 @@ public class SampleDataUtil {
         return new Client[]{
             new Client(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"), new Country("SG"), new Timezone("GMT+8"),
-                new ContractExpiryDate(LocalDate.of(2022, 4, 21)), getTagSet("friends")),
+                new ContractExpiryDate("21-4-2022"), getTagSet("friends")),
             new Client(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new Country("SG"),
-                new Timezone("GMT+8"), new ContractExpiryDate(LocalDate.of(2021, 12, 12)),
+                new Timezone("GMT+8"), new ContractExpiryDate("12-12-2021"),
                 getTagSet("colleagues", "friends")),
             new Client(new Name("Charlotte Oliveiro"), new Phone("93210283"),
                 new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new Country("SG"), new Timezone("GMT+8"),
-                new ContractExpiryDate(LocalDate.of(2023, 4, 1)), getTagSet("neighbours")),
+                new ContractExpiryDate("1-4-2023"), getTagSet("neighbours")),
             new Client(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new Country("SG"),
-                new Timezone("GMT+8"), new ContractExpiryDate(LocalDate.of(2020, 12, 23)),
+                new Timezone("GMT+8"), new ContractExpiryDate("23-12-2020"),
                 getTagSet("family")),
             new Client(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"), new Country("SG"), new Timezone("GMT+8"),
-                new ContractExpiryDate(LocalDate.of(2021, 2, 3)), getTagSet("classmates")),
+                new ContractExpiryDate("3-2-2021"), getTagSet("classmates")),
             new Client(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"), new Country("SG"), new Timezone("GMT+8"),
-                new ContractExpiryDate(LocalDate.of(2024, 6, 9)), getTagSet("colleagues"))
+                new ContractExpiryDate("9-6-2024"), getTagSet("colleagues"))
         };
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -11,7 +11,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
-import seedu.address.model.client.Date;
+import seedu.address.model.client.ContractExpiryDate;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -29,25 +29,25 @@ public class SampleDataUtil {
         return new Client[]{
             new Client(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"), new Country("SG"), new Timezone("GMT+8"),
-                new Date(LocalDate.of(2022, 4, 21)), getTagSet("friends")),
+                new ContractExpiryDate(LocalDate.of(2022, 4, 21)), getTagSet("friends")),
             new Client(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new Country("SG"),
-                new Timezone("GMT+8"), new Date(LocalDate.of(2021, 12, 12)),
+                new Timezone("GMT+8"), new ContractExpiryDate(LocalDate.of(2021, 12, 12)),
                 getTagSet("colleagues", "friends")),
             new Client(new Name("Charlotte Oliveiro"), new Phone("93210283"),
                 new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new Country("SG"), new Timezone("GMT+8"),
-                new Date(LocalDate.of(2023, 4, 1)), getTagSet("neighbours")),
+                new ContractExpiryDate(LocalDate.of(2023, 4, 1)), getTagSet("neighbours")),
             new Client(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new Country("SG"),
-                new Timezone("GMT+8"), new Date(LocalDate.of(2020, 12, 23)),
+                new Timezone("GMT+8"), new ContractExpiryDate(LocalDate.of(2020, 12, 23)),
                 getTagSet("family")),
             new Client(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"), new Country("SG"), new Timezone("GMT+8"),
-                new Date(LocalDate.of(2021, 2, 3)), getTagSet("classmates")),
+                new ContractExpiryDate(LocalDate.of(2021, 2, 3)), getTagSet("classmates")),
             new Client(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"), new Country("SG"), new Timezone("GMT+8"),
-                new Date(LocalDate.of(2024, 6, 9)), getTagSet("colleagues"))
+                new ContractExpiryDate(LocalDate.of(2024, 6, 9)), getTagSet("colleagues"))
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedClient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedClient.java
@@ -13,7 +13,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
-import seedu.address.model.client.Date;
+import seedu.address.model.client.ContractExpiryDate;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -137,16 +137,17 @@ class JsonAdaptedClient {
 
         if (contractExpiryDate == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
-                    Date.class.getSimpleName()));
+                    ContractExpiryDate.class.getSimpleName()));
         }
-        if (!Date.isValidDate(contractExpiryDate)) {
-            throw new IllegalValueException(Date.MESSAGE_CONSTRAINTS);
+        if (!ContractExpiryDate.isValidDate(contractExpiryDate)) {
+            throw new IllegalValueException(ContractExpiryDate.MESSAGE_CONSTRAINTS);
         }
-        final Date modelContractExpiryDate = ParserUtil.parseContractExpiryDate(contractExpiryDate);
+        final ContractExpiryDate modelContractExpiryContractExpiryDate =
+                ParserUtil.parseContractExpiryDate(contractExpiryDate);
 
         final Set<Tag> modelTags = new HashSet<>(clientTags);
         return new Client(modelName, modelPhone, modelEmail, modelAddress, modelCountry, modelTimezone,
-                modelContractExpiryDate, modelTags);
+                modelContractExpiryContractExpiryDate, modelTags);
     }
 
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedClient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedClient.java
@@ -10,8 +10,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.parser.ParserUtil;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.Date;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -33,6 +35,7 @@ class JsonAdaptedClient {
     private final String address;
     private final String country;
     private final String timezone;
+    private final String contractExpiryDate;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
 
     /**
@@ -42,6 +45,7 @@ class JsonAdaptedClient {
     public JsonAdaptedClient(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
                              @JsonProperty("email") String email, @JsonProperty("address") String address,
                              @JsonProperty("country") String country, @JsonProperty("timezone") String timezone,
+                             @JsonProperty("contractExpiryDate") String contractExpiryDate,
                              @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.name = name;
         this.phone = phone;
@@ -49,6 +53,7 @@ class JsonAdaptedClient {
         this.address = address;
         this.country = country;
         this.timezone = timezone;
+        this.contractExpiryDate = contractExpiryDate;
         if (tagged != null) {
             this.tagged.addAll(tagged);
         }
@@ -64,6 +69,7 @@ class JsonAdaptedClient {
         address = source.getAddress().value;
         country = source.getCountry().getCountryCode();
         timezone = source.getTimezone().value;
+        contractExpiryDate = source.getContractExpiryDate().value;
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -129,8 +135,18 @@ class JsonAdaptedClient {
         }
         final Timezone modelTimezone = new Timezone(timezone);
 
+        if (contractExpiryDate == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    Date.class.getSimpleName()));
+        }
+        if (!Date.isValidDate(contractExpiryDate)) {
+            throw new IllegalValueException(Date.MESSAGE_CONSTRAINTS);
+        }
+        final Date modelContractExpiryDate = ParserUtil.parseContractExpiryDate(contractExpiryDate);
+
         final Set<Tag> modelTags = new HashSet<>(clientTags);
-        return new Client(modelName, modelPhone, modelEmail, modelAddress, modelCountry, modelTimezone, modelTags);
+        return new Client(modelName, modelPhone, modelEmail, modelAddress, modelCountry, modelTimezone,
+                modelContractExpiryDate, modelTags);
     }
 
 }

--- a/src/main/java/seedu/address/ui/ClientCard.java
+++ b/src/main/java/seedu/address/ui/ClientCard.java
@@ -43,6 +43,8 @@ public class ClientCard extends UiPart<Region> {
     @FXML
     private Label timezone;
     @FXML
+    private Label contractExpiryDate;
+    @FXML
     private FlowPane tags;
 
     /**
@@ -58,6 +60,7 @@ public class ClientCard extends UiPart<Region> {
         email.setText(client.getEmail().value);
         country.setText(client.getCountry().getCountryName());
         timezone.setText(client.getTimezone().value);
+        contractExpiryDate.setText(client.getContractExpiryDate().value);
         client.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/ClientListCard.fxml
+++ b/src/main/resources/view/ClientListCard.fxml
@@ -33,6 +33,7 @@
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <Label fx:id="country" styleClass="cell_small_label" text="\$country" />
       <Label fx:id="timezone" styleClass="cell_small_label" text="\$timezone" />
+      <Label fx:id="contractExpiryDate" styleClass="cell_small_label" text="\$contractExpiryDate" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/data/JsonSerializableAddressBookTest/duplicateClientAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicateClientAddressBook.json
@@ -6,6 +6,7 @@
     "address": "123, Jurong West Ave 6, #08-111",
     "country": "SG",
     "timezone": "GMT+8",
+    "contractExpiryDate": "10-9-2020",
     "tagged": [ "friends" ]
   }, {
     "name": "Alice Pauline",
@@ -13,6 +14,7 @@
     "email": "pauline@example.com",
     "country": "SG",
     "timezone": "GMT+8",
+    "contractExpiryDate": "10-9-2020",
     "address": "4th street"
   } ],
   "notes": []

--- a/src/test/data/JsonSerializableAddressBookTest/typicalClientsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalClientsAddressBook.json
@@ -7,6 +7,7 @@
     "address" : "123, Jurong West Ave 6, #08-111",
     "country" : "SG",
     "timezone": "GMT+8",
+    "contractExpiryDate": "1-4-2021",
     "tagged" : [ "friends" ]
   }, {
     "name" : "Benson Meier",
@@ -15,6 +16,7 @@
     "address" : "311, Clementi Ave 2, #02-25",
     "country" : "SG",
     "timezone": "GMT+8",
+    "contractExpiryDate": "3-12-2022",
     "tagged" : [ "owesMoney", "friends" ]
   }, {
     "name" : "Carl Kurz",
@@ -23,6 +25,7 @@
     "address" : "wall street",
     "country" : "US",
     "timezone": "GMT-4",
+    "contractExpiryDate": "30-1-2022",
     "tagged" : [ ]
   }, {
     "name" : "Daniel Meier",
@@ -31,6 +34,7 @@
     "address" : "10th street",
     "country" : "SG",
     "timezone": "GMT+8",
+    "contractExpiryDate": "28-2-2021",
     "tagged" : [ "friends" ]
   }, {
     "name" : "Elle Meyer",
@@ -39,6 +43,7 @@
     "address" : "michegan ave",
     "country" : "GB",
     "timezone": "GMT+1",
+    "contractExpiryDate": "10-10-2024",
     "tagged" : [ ]
   }, {
     "name" : "Fiona Kunz",
@@ -47,6 +52,7 @@
     "address" : "little tokyo",
     "country" : "JP",
     "timezone": "GMT+9",
+    "contractExpiryDate": "9-11-2022",
     "tagged" : [ ]
   }, {
     "name" : "George Best",
@@ -55,6 +61,7 @@
     "address" : "4th street",
     "country" : "US",
     "timezone": "GMT-4",
+    "contractExpiryDate": "2-8-2021",
     "tagged" : [ ]
   } ],
   "notes": []

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.CONTRACT_EXPIRY_DATE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.COUNTRY_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
@@ -82,7 +83,7 @@ public class LogicManagerTest {
 
         // Execute add command
         String addCommand = ClientAddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
-                + ADDRESS_DESC_AMY + COUNTRY_DESC_AMY + TIMEZONE_DESC_AMY;
+                + ADDRESS_DESC_AMY + COUNTRY_DESC_AMY + TIMEZONE_DESC_AMY + CONTRACT_EXPIRY_DATE_DESC_AMY;
         Client expectedClient = new ClientBuilder(AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addClient(expectedClient);

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -85,10 +85,12 @@ public class CommandTestUtil {
     static {
         DESC_AMY = new EditClientDescriptorBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
                 .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withCountry(VALID_COUNTRY_AMY)
-                .withTimezone(VALID_TIMEZONE_AMY).withTags(VALID_TAG_FRIEND).build();
+                .withTimezone(VALID_TIMEZONE_AMY).withContractExpiryDate(VALID_CONTRACT_EXPIRY_DATE_AMY)
+                .withTags(VALID_TAG_FRIEND).build();
         DESC_BOB = new EditClientDescriptorBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withCountry(VALID_COUNTRY_BOB)
-                .withTimezone(VALID_TIMEZONE_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withTimezone(VALID_TIMEZONE_BOB).withContractExpiryDate(VALID_CONTRACT_EXPIRY_DATE_BOB)
+                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTRACT_EXPIRY_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNTRY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -40,6 +41,8 @@ public class CommandTestUtil {
     public static final String VALID_COUNTRY_BOB = "MY";
     public static final String VALID_TIMEZONE_AMY = "GMT+8";
     public static final String VALID_TIMEZONE_BOB = "GMT+7";
+    public static final String VALID_CONTRACT_EXPIRY_DATE_AMY = "1-1-2022";
+    public static final String VALID_CONTRACT_EXPIRY_DATE_BOB = "13-12-2021";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
@@ -55,6 +58,10 @@ public class CommandTestUtil {
     public static final String COUNTRY_DESC_BOB = " " + PREFIX_COUNTRY + VALID_COUNTRY_BOB;
     public static final String TIMEZONE_DESC_AMY = " " + PREFIX_TIMEZONE + VALID_TIMEZONE_AMY;
     public static final String TIMEZONE_DESC_BOB = " " + PREFIX_TIMEZONE + VALID_TIMEZONE_BOB;
+    public static final String CONTRACT_EXPIRY_DATE_DESC_AMY =
+            " " + PREFIX_CONTRACT_EXPIRY_DATE + VALID_CONTRACT_EXPIRY_DATE_AMY;
+    public static final String CONTRACT_EXPIRY_DATE_DESC_BOB =
+            " " + PREFIX_CONTRACT_EXPIRY_DATE + VALID_CONTRACT_EXPIRY_DATE_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
@@ -65,6 +72,8 @@ public class CommandTestUtil {
     public static final String INVALID_COUNTRY_DESC = " " + PREFIX_COUNTRY + "ZZ"; // not a valid country code
     public static final String INVALID_TIMEZONE_DESC = " " + PREFIX_TIMEZONE + "GT+8"; // not a valid timezone input
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_CONTRACT_EXPIRY_DATE_DESC =
+            " " + PREFIX_CONTRACT_EXPIRY_DATE + "31-2-2020"; // 31st of Feb is not a valid date
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/parser/ClientAddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ClientAddCommandParserTest.java
@@ -28,7 +28,6 @@ import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.TIMEZONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.TIMEZONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_CONTRACT_EXPIRY_DATE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_CONTRACT_EXPIRY_DATE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COUNTRY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;

--- a/src/test/java/seedu/address/logic/parser/ClientAddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ClientAddCommandParserTest.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.ClientAddCommand;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
-import seedu.address.model.client.Date;
+import seedu.address.model.client.ContractExpiryDate;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -204,7 +204,7 @@ public class ClientAddCommandParserTest {
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + INVALID_CONTRACT_EXPIRY_DATE_DESC
                 + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                Date.MESSAGE_CONSTRAINTS);
+                ContractExpiryDate.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB

--- a/src/test/java/seedu/address/logic/parser/ClientAddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ClientAddCommandParserTest.java
@@ -3,11 +3,14 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.CONTRACT_EXPIRY_DATE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.CONTRACT_EXPIRY_DATE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.COUNTRY_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.COUNTRY_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_CONTRACT_EXPIRY_DATE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_COUNTRY_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
@@ -25,6 +28,8 @@ import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.TIMEZONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.TIMEZONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_CONTRACT_EXPIRY_DATE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_CONTRACT_EXPIRY_DATE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COUNTRY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
@@ -42,6 +47,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.ClientAddCommand;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.Date;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -59,44 +65,58 @@ public class ClientAddCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + TAG_DESC_FRIEND,
+                + ADDRESS_DESC_BOB + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB
+                + CONTRACT_EXPIRY_DATE_DESC_BOB + TAG_DESC_FRIEND,
                 new ClientAddCommand(expectedClient));
 
         // multiple names - last name accepted
         assertParseSuccess(parser, NAME_DESC_AMY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + TAG_DESC_FRIEND,
+                + ADDRESS_DESC_BOB + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB
+                + CONTRACT_EXPIRY_DATE_DESC_BOB + TAG_DESC_FRIEND,
                 new ClientAddCommand(expectedClient));
 
         // multiple phones - last phone accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_AMY + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + TAG_DESC_FRIEND,
+                + ADDRESS_DESC_BOB + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB
+                + CONTRACT_EXPIRY_DATE_DESC_BOB + TAG_DESC_FRIEND,
                 new ClientAddCommand(expectedClient));
 
         // multiple emails - last email accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_AMY + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + TAG_DESC_FRIEND,
+                + ADDRESS_DESC_BOB + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB
+                + CONTRACT_EXPIRY_DATE_DESC_BOB + TAG_DESC_FRIEND,
                 new ClientAddCommand(expectedClient));
 
         // multiple addresses - last address accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_AMY
-                + ADDRESS_DESC_BOB + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + TAG_DESC_FRIEND,
+                + ADDRESS_DESC_BOB + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB
+                + CONTRACT_EXPIRY_DATE_DESC_BOB + TAG_DESC_FRIEND,
                 new ClientAddCommand(expectedClient));
 
         // multiple countries - last country accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + COUNTRY_DESC_AMY + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + TAG_DESC_FRIEND,
+                + COUNTRY_DESC_AMY + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB
+                + CONTRACT_EXPIRY_DATE_DESC_BOB + TAG_DESC_FRIEND,
                 new ClientAddCommand(expectedClient));
 
         // multiple timezones - last timezone accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                        + COUNTRY_DESC_BOB + TIMEZONE_DESC_AMY + TIMEZONE_DESC_BOB + TAG_DESC_FRIEND,
+                + COUNTRY_DESC_BOB + TIMEZONE_DESC_AMY + TIMEZONE_DESC_BOB
+                + CONTRACT_EXPIRY_DATE_DESC_BOB + TAG_DESC_FRIEND,
+                new ClientAddCommand(expectedClient));
+
+        // multiple contract expiry dates - last date accepted
+        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + CONTRACT_EXPIRY_DATE_DESC_AMY
+                + CONTRACT_EXPIRY_DATE_DESC_BOB + TAG_DESC_FRIEND,
                 new ClientAddCommand(expectedClient));
 
         // multiple tags - all accepted
         Client expectedClientMultipleTags = new ClientBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .build();
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + CONTRACT_EXPIRY_DATE_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 new ClientAddCommand(expectedClientMultipleTags));
     }
 
@@ -105,7 +125,7 @@ public class ClientAddCommandParserTest {
         // zero tags
         Client expectedClient = new ClientBuilder(AMY).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                        + COUNTRY_DESC_AMY + TIMEZONE_DESC_AMY,
+                        + COUNTRY_DESC_AMY + TIMEZONE_DESC_AMY + CONTRACT_EXPIRY_DATE_DESC_AMY,
                 new ClientAddCommand(expectedClient));
     }
 
@@ -115,74 +135,92 @@ public class ClientAddCommandParserTest {
 
         // missing name prefix
         assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB, expectedMessage);
+                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + CONTRACT_EXPIRY_DATE_DESC_BOB, expectedMessage);
 
         // missing phone prefix
         assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB, expectedMessage);
+                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + CONTRACT_EXPIRY_DATE_DESC_BOB, expectedMessage);
 
         // missing email prefix
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB
-                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB, expectedMessage);
+                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + CONTRACT_EXPIRY_DATE_DESC_BOB, expectedMessage);
 
         // missing address prefix
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB
-                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB, expectedMessage);
+                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + CONTRACT_EXPIRY_DATE_DESC_BOB, expectedMessage);
 
         // missing country prefix
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + VALID_COUNTRY_BOB + TIMEZONE_DESC_BOB, expectedMessage);
+                + VALID_COUNTRY_BOB + TIMEZONE_DESC_BOB + CONTRACT_EXPIRY_DATE_DESC_BOB, expectedMessage);
 
         // missing timezone prefix
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
                 + COUNTRY_DESC_BOB + VALID_TIMEZONE_BOB, expectedMessage);
 
+        // missing contract expiry date prefix
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + VALID_CONTRACT_EXPIRY_DATE_BOB, expectedMessage);
+
         // all prefixes missing
         assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB
-                + VALID_COUNTRY_BOB + VALID_TIMEZONE_BOB, expectedMessage);
+                + VALID_COUNTRY_BOB + VALID_TIMEZONE_BOB + VALID_CONTRACT_EXPIRY_DATE_BOB, expectedMessage);
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + CONTRACT_EXPIRY_DATE_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + CONTRACT_EXPIRY_DATE_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
 
         // invalid email
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
-                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
+                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + CONTRACT_EXPIRY_DATE_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
 
         // invalid address
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + CONTRACT_EXPIRY_DATE_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 Address.MESSAGE_CONSTRAINTS);
 
         // invalid country
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_COUNTRY_DESC + TIMEZONE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                + INVALID_COUNTRY_DESC + TIMEZONE_DESC_BOB + CONTRACT_EXPIRY_DATE_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 Country.MESSAGE_CONSTRAINTS);
 
         // invalid timezone
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                        + COUNTRY_DESC_BOB + INVALID_TIMEZONE_DESC + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                + COUNTRY_DESC_BOB + INVALID_TIMEZONE_DESC + CONTRACT_EXPIRY_DATE_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 Timezone.MESSAGE_CONSTRAINTS);
+
+        // invalid contract expiry date
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + INVALID_CONTRACT_EXPIRY_DATE_DESC
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                Date.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+                + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + CONTRACT_EXPIRY_DATE_DESC_BOB
+                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                + INVALID_COUNTRY_DESC + TIMEZONE_DESC_BOB,
+                + INVALID_COUNTRY_DESC + TIMEZONE_DESC_BOB + CONTRACT_EXPIRY_DATE_DESC_BOB,
                 Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                + ADDRESS_DESC_BOB + COUNTRY_DESC_BOB + TIMEZONE_DESC_BOB + CONTRACT_EXPIRY_DATE_DESC_BOB
+                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, ClientAddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/model/client/ContractExpiryDateTest.java
+++ b/src/test/java/seedu/address/model/client/ContractExpiryDateTest.java
@@ -1,0 +1,82 @@
+package seedu.address.model.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+public class ContractExpiryDateTest {
+
+    private static final LocalDate TEST_DATE_1 = LocalDate.of(2020, 12, 11);
+    private static final String TEST_DATE_1_STRING = "11-12-2020";
+    private static final LocalDate TEST_DATE_2 = LocalDate.of(2019, 1, 30);
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new ContractExpiryDate(null));
+    }
+
+    @Test
+    public void equals() {
+        // Same date, return true
+        ContractExpiryDate contractExpiryDate = new ContractExpiryDate(TEST_DATE_1);
+        assertTrue(contractExpiryDate.equals(new ContractExpiryDate(TEST_DATE_1)));
+        // Different date, return false
+        assertFalse(contractExpiryDate.equals(new ContractExpiryDate(TEST_DATE_2)));
+    }
+
+    @Test
+    public void hashCode_test() {
+        // Same date, return same hashcode
+        ContractExpiryDate contractExpiryDate = new ContractExpiryDate(TEST_DATE_1);
+        assertEquals(contractExpiryDate.hashCode(), new ContractExpiryDate(TEST_DATE_1).hashCode());
+        // Different date, return different hashcode
+        assertNotEquals(contractExpiryDate.hashCode(), new ContractExpiryDate(TEST_DATE_2).hashCode());
+    }
+
+    @Test
+    public void compareTo() {
+        ContractExpiryDate contractExpiryDate1 = new ContractExpiryDate(TEST_DATE_1);
+        ContractExpiryDate contractExpiryDate2 = new ContractExpiryDate(TEST_DATE_2);
+        assertTrue(contractExpiryDate1.compareTo(contractExpiryDate2) > 0);
+        assertTrue(contractExpiryDate2.compareTo(contractExpiryDate1) < 0);
+    }
+
+    @Test
+    public void toString_test() {
+        ContractExpiryDate contractExpiryDate = new ContractExpiryDate(TEST_DATE_1);
+        assertEquals(contractExpiryDate.toString(), TEST_DATE_1_STRING);
+    }
+
+    @Test
+    public void isValidDate() {
+        // null timezone
+        assertThrows(NullPointerException.class, () -> ContractExpiryDate.isValidDate(null));
+
+        // invalid timezone
+        assertFalse(ContractExpiryDate.isValidDate("")); // empty string
+        assertFalse(ContractExpiryDate.isValidDate(" ")); // spaces only
+        assertFalse(ContractExpiryDate.isValidDate("30")); // number only
+        assertFalse(ContractExpiryDate.isValidDate("30-2")); // 2 numbers only
+        assertFalse(ContractExpiryDate.isValidDate("001-2-2049")); // 3 digit day
+        assertFalse(ContractExpiryDate.isValidDate("1-200-2029")); // 3 digit month
+        assertFalse(ContractExpiryDate.isValidDate("1-20-0")); // 1 digit year
+        assertFalse(ContractExpiryDate.isValidDate("1-20-020")); // 3 digit year
+        assertFalse(ContractExpiryDate.isValidDate("1-20-20020")); // 5 digit year
+        assertFalse(ContractExpiryDate.isValidDate("1-0-20")); // month is 0
+        assertFalse(ContractExpiryDate.isValidDate("0-1-20")); // day is 0
+        assertFalse(ContractExpiryDate.isValidDate("32-12-2020")); // day is 32
+        assertFalse(ContractExpiryDate.isValidDate("12-13-2023")); // month is 13
+        assertFalse(ContractExpiryDate.isValidDate("30/1/2021")); // slashes are used
+
+        // valid timezone
+        assertTrue(ContractExpiryDate.isValidDate("12-12-20")); // valid date
+        assertTrue(ContractExpiryDate.isValidDate("1-1-0000")); // smallest possible date
+        assertTrue(ContractExpiryDate.isValidDate("31-12-9999")); // largest possible date
+    }
+}

--- a/src/test/java/seedu/address/model/client/ContractExpiryDateTest.java
+++ b/src/test/java/seedu/address/model/client/ContractExpiryDateTest.java
@@ -6,15 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
-import java.time.LocalDate;
-
 import org.junit.jupiter.api.Test;
 
 public class ContractExpiryDateTest {
 
-    private static final LocalDate TEST_DATE_1 = LocalDate.of(2020, 12, 11);
-    private static final String TEST_DATE_1_STRING = "11-12-2020";
-    private static final LocalDate TEST_DATE_2 = LocalDate.of(2019, 1, 30);
+    private static final String TEST_DATE_1 = "11-12-2020";
+    private static final String TEST_DATE_2 = "30-1-2019";
 
     @Test
     public void constructor_null_throwsNullPointerException() {
@@ -50,15 +47,15 @@ public class ContractExpiryDateTest {
     @Test
     public void toString_test() {
         ContractExpiryDate contractExpiryDate = new ContractExpiryDate(TEST_DATE_1);
-        assertEquals(contractExpiryDate.toString(), TEST_DATE_1_STRING);
+        assertEquals(contractExpiryDate.toString(), TEST_DATE_1);
     }
 
     @Test
     public void isValidDate() {
-        // null timezone
+        // null dates
         assertThrows(NullPointerException.class, () -> ContractExpiryDate.isValidDate(null));
 
-        // invalid timezone
+        // invalid dates
         assertFalse(ContractExpiryDate.isValidDate("")); // empty string
         assertFalse(ContractExpiryDate.isValidDate(" ")); // spaces only
         assertFalse(ContractExpiryDate.isValidDate("30")); // number only
@@ -73,9 +70,12 @@ public class ContractExpiryDateTest {
         assertFalse(ContractExpiryDate.isValidDate("32-12-2020")); // day is 32
         assertFalse(ContractExpiryDate.isValidDate("12-13-2023")); // month is 13
         assertFalse(ContractExpiryDate.isValidDate("30/1/2021")); // slashes are used
+        assertFalse(ContractExpiryDate.isValidDate("30-2-2021")); // 30th Feb
+        assertFalse(ContractExpiryDate.isValidDate("29-2-2021")); // 29th Feb on non-leap year
 
-        // valid timezone
+        // valid dates
         assertTrue(ContractExpiryDate.isValidDate("12-12-20")); // valid date
+        assertTrue(ContractExpiryDate.isValidDate("29-2-2020")); // 29th Feb on leap year
         assertTrue(ContractExpiryDate.isValidDate("1-1-0000")); // smallest possible date
         assertTrue(ContractExpiryDate.isValidDate("31-12-9999")); // largest possible date
     }

--- a/src/test/java/seedu/address/model/client/TimezoneTest.java
+++ b/src/test/java/seedu/address/model/client/TimezoneTest.java
@@ -20,7 +20,7 @@ public class TimezoneTest {
     }
 
     @Test
-    public void isValidName() {
+    public void isValidTimezone() {
         // null timezone
         assertThrows(NullPointerException.class, () -> Timezone.isValidTimezone(null));
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedClientTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedClientTest.java
@@ -13,9 +13,11 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.client.Address;
+import seedu.address.model.client.Date;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
+import seedu.address.model.client.Timezone;
 import seedu.address.model.country.Country;
 
 public class JsonAdaptedClientTest {
@@ -25,14 +27,16 @@ public class JsonAdaptedClientTest {
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_COUNTRY = "ZZ";
     private static final String INVALID_TIMEZONE = "GT+8";
+    private static final String INVALID_CONTRACT_EXPIRY_DATE = "1,2,2020";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
-    private static final String VALID_COUNTRY = BENSON.getCountry().toString();
+    private static final String VALID_COUNTRY = BENSON.getCountry().getCountryCode();
     private static final String VALID_TIMEZONE = BENSON.getTimezone().toString();
+    private static final String VALID_CONTRACT_EXPIRY_DATE = BENSON.getContractExpiryDate().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -46,7 +50,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -54,7 +58,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -62,7 +66,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -70,7 +74,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -78,7 +82,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -86,7 +90,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -94,7 +98,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -102,7 +106,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_COUNTRY, VALID_TIMEZONE, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -110,7 +114,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_invalidCountry_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                INVALID_COUNTRY, VALID_TIMEZONE, VALID_TAGS);
+                INVALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
         String expectedMessage = Country.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -118,8 +122,40 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_nullCountry_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                null, VALID_TIMEZONE, VALID_TAGS);
+                null, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Country.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidTimezone_throwsIllegalValueException() {
+        JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_COUNTRY, INVALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
+        String expectedMessage = Timezone.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullTimezone_throwsIllegalValueException() {
+        JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_COUNTRY, null, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Timezone.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidContractExpiryDate_throwsIllegalValueException() {
+        JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_COUNTRY, VALID_TIMEZONE, INVALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
+        String expectedMessage = Date.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullContractExpiryDate_throwsIllegalValueException() {
+        JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_COUNTRY, VALID_TIMEZONE, null, VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 
@@ -128,7 +164,7 @@ public class JsonAdaptedClientTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, invalidTags);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, invalidTags);
         assertThrows(IllegalValueException.class, client::toModelType);
     }
 

--- a/src/test/java/seedu/address/storage/JsonAdaptedClientTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedClientTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.client.Address;
-import seedu.address.model.client.Date;
+import seedu.address.model.client.ContractExpiryDate;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -147,7 +147,7 @@ public class JsonAdaptedClientTest {
     public void toModelType_invalidContractExpiryDate_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                 VALID_COUNTRY, VALID_TIMEZONE, INVALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
-        String expectedMessage = Date.MESSAGE_CONSTRAINTS;
+        String expectedMessage = ContractExpiryDate.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 
@@ -155,7 +155,7 @@ public class JsonAdaptedClientTest {
     public void toModelType_nullContractExpiryDate_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                 VALID_COUNTRY, VALID_TIMEZONE, null, VALID_TAGS);
-        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Date.class.getSimpleName());
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, ContractExpiryDate.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/ClientBuilder.java
+++ b/src/test/java/seedu/address/testutil/ClientBuilder.java
@@ -7,7 +7,7 @@ import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
-import seedu.address.model.client.Date;
+import seedu.address.model.client.ContractExpiryDate;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -35,7 +35,7 @@ public class ClientBuilder {
     private Address address;
     private Country country;
     private Timezone timezone;
-    private Date contractExpiryDate;
+    private ContractExpiryDate contractExpiryDate;
     private Set<Tag> tags;
 
     /**
@@ -127,7 +127,7 @@ public class ClientBuilder {
     }
 
     /**
-     * Sets the {@code Date} of the {@code Client} that we are building.
+     * Sets the {@code ContractExpiryDate} of the {@code Client} that we are building.
      */
     public ClientBuilder withContractExpiryDate(String contractExpiryDate) {
         try {

--- a/src/test/java/seedu/address/testutil/ClientBuilder.java
+++ b/src/test/java/seedu/address/testutil/ClientBuilder.java
@@ -3,8 +3,6 @@ package seedu.address.testutil;
 import java.util.HashSet;
 import java.util.Set;
 
-import seedu.address.logic.parser.ParserUtil;
-import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
 import seedu.address.model.client.ContractExpiryDate;
@@ -48,11 +46,7 @@ public class ClientBuilder {
         address = new Address(DEFAULT_ADDRESS);
         country = new Country(DEFAULT_COUNTRY);
         timezone = new Timezone(DEFAULT_TIMEZONE);
-        try {
-            contractExpiryDate = ParserUtil.parseContractExpiryDate(DEFAULT_CONTRACT_EXPIRY_DATE);
-        } catch (ParseException ignored) {
-            // Intentionally left empty, since if contractExpiryDate fails to initialize, other tests will fail as well.
-        }
+        contractExpiryDate = new ContractExpiryDate(DEFAULT_CONTRACT_EXPIRY_DATE);
         tags = new HashSet<>();
     }
 
@@ -130,11 +124,7 @@ public class ClientBuilder {
      * Sets the {@code ContractExpiryDate} of the {@code Client} that we are building.
      */
     public ClientBuilder withContractExpiryDate(String contractExpiryDate) {
-        try {
-            this.contractExpiryDate = ParserUtil.parseContractExpiryDate(contractExpiryDate);
-        } catch (ParseException ignored) {
-            // Intentionally left empty, since if contractExpiryDate fails to initialize, other tests will fail as well.
-        }
+        this.contractExpiryDate = new ContractExpiryDate(contractExpiryDate);
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/ClientBuilder.java
+++ b/src/test/java/seedu/address/testutil/ClientBuilder.java
@@ -3,8 +3,11 @@ package seedu.address.testutil;
 import java.util.HashSet;
 import java.util.Set;
 
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.Date;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -24,6 +27,7 @@ public class ClientBuilder {
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
     public static final String DEFAULT_COUNTRY = "SG";
     public static final String DEFAULT_TIMEZONE = "GMT+8";
+    public static final String DEFAULT_CONTRACT_EXPIRY_DATE = "4-1-2021";
 
     private Name name;
     private Phone phone;
@@ -31,6 +35,7 @@ public class ClientBuilder {
     private Address address;
     private Country country;
     private Timezone timezone;
+    private Date contractExpiryDate;
     private Set<Tag> tags;
 
     /**
@@ -43,6 +48,11 @@ public class ClientBuilder {
         address = new Address(DEFAULT_ADDRESS);
         country = new Country(DEFAULT_COUNTRY);
         timezone = new Timezone(DEFAULT_TIMEZONE);
+        try {
+            contractExpiryDate = ParserUtil.parseContractExpiryDate(DEFAULT_CONTRACT_EXPIRY_DATE);
+        } catch (ParseException ignored) {
+            // Intentionally left empty, since if contractExpiryDate fails to initialize, other tests will fail as well.
+        }
         tags = new HashSet<>();
     }
 
@@ -56,6 +66,7 @@ public class ClientBuilder {
         address = clientToCopy.getAddress();
         country = clientToCopy.getCountry();
         timezone = clientToCopy.getTimezone();
+        contractExpiryDate = clientToCopy.getContractExpiryDate();
         tags = new HashSet<>(clientToCopy.getTags());
     }
 
@@ -115,8 +126,20 @@ public class ClientBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code Date} of the {@code Client} that we are building.
+     */
+    public ClientBuilder withContractExpiryDate(String contractExpiryDate) {
+        try {
+            this.contractExpiryDate = ParserUtil.parseContractExpiryDate(contractExpiryDate);
+        } catch (ParseException ignored) {
+            // Intentionally left empty, since if contractExpiryDate fails to initialize, other tests will fail as well.
+        }
+        return this;
+    }
+
     public Client build() {
-        return new Client(name, phone, email, address, country, timezone, tags);
+        return new Client(name, phone, email, address, country, timezone, contractExpiryDate, tags);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/ClientUtil.java
+++ b/src/test/java/seedu/address/testutil/ClientUtil.java
@@ -1,6 +1,7 @@
 package seedu.address.testutil;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CONTRACT_EXPIRY_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNTRY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
@@ -39,6 +40,7 @@ public class ClientUtil {
         sb.append(PREFIX_ADDRESS + client.getAddress().value + " ");
         sb.append(PREFIX_COUNTRY + client.getCountry().getCountryCode() + " ");
         sb.append(PREFIX_TIMEZONE + client.getTimezone().value + " ");
+        sb.append(PREFIX_CONTRACT_EXPIRY_DATE + client.getContractExpiryDate().value + " ");
         client.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );
@@ -57,6 +59,8 @@ public class ClientUtil {
         descriptor.getCountry().ifPresent(country -> sb.append(PREFIX_COUNTRY).append(country.getCountryCode())
                 .append(" "));
         descriptor.getTimezone().ifPresent(timezone -> sb.append(PREFIX_TIMEZONE).append(timezone.value).append(" "));
+        descriptor.getContractExpiryDate().ifPresent(contractExpiryDate ->
+                sb.append(PREFIX_CONTRACT_EXPIRY_DATE).append(contractExpiryDate.value).append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {

--- a/src/test/java/seedu/address/testutil/EditClientDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditClientDescriptorBuilder.java
@@ -5,6 +5,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.ClientEditCommand.EditClientDescriptor;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
 import seedu.address.model.client.Email;
@@ -19,7 +21,7 @@ import seedu.address.model.tag.Tag;
  */
 public class EditClientDescriptorBuilder {
 
-    private EditClientDescriptor descriptor;
+    private final EditClientDescriptor descriptor;
 
     public EditClientDescriptorBuilder() {
         descriptor = new EditClientDescriptor();
@@ -40,6 +42,7 @@ public class EditClientDescriptorBuilder {
         descriptor.setAddress(client.getAddress());
         descriptor.setCountry(client.getCountry());
         descriptor.setTimezone(client.getTimezone());
+        descriptor.setContractExpiryDate(client.getContractExpiryDate());
         descriptor.setTags(client.getTags());
     }
 
@@ -88,6 +91,18 @@ public class EditClientDescriptorBuilder {
      */
     public EditClientDescriptorBuilder withTimezone(String timezone) {
         descriptor.setTimezone(new Timezone(timezone));
+        return this;
+    }
+
+    /**
+     * Sets the {@code contractExpiryDate} of the {@code EditClientDescriptor} that we are building.
+     */
+    public EditClientDescriptorBuilder withContractExpiryDate(String contractExpiryDate) {
+        try {
+            descriptor.setContractExpiryDate(ParserUtil.parseContractExpiryDate(contractExpiryDate));
+        } catch (ParseException ignored) {
+            // Intentionally left empty, since if contractExpiryDate fails to initialize, other tests will fail as well.
+        }
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/EditClientDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditClientDescriptorBuilder.java
@@ -5,10 +5,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.ClientEditCommand.EditClientDescriptor;
-import seedu.address.logic.parser.ParserUtil;
-import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
+import seedu.address.model.client.ContractExpiryDate;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
@@ -98,11 +97,7 @@ public class EditClientDescriptorBuilder {
      * Sets the {@code contractExpiryDate} of the {@code EditClientDescriptor} that we are building.
      */
     public EditClientDescriptorBuilder withContractExpiryDate(String contractExpiryDate) {
-        try {
-            descriptor.setContractExpiryDate(ParserUtil.parseContractExpiryDate(contractExpiryDate));
-        } catch (ParseException ignored) {
-            // Intentionally left empty, since if contractExpiryDate fails to initialize, other tests will fail as well.
-        }
+        descriptor.setContractExpiryDate(new ContractExpiryDate(contractExpiryDate));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalClients.java
+++ b/src/test/java/seedu/address/testutil/TypicalClients.java
@@ -2,6 +2,8 @@ package seedu.address.testutil;
 
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_CONTRACT_EXPIRY_DATE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_CONTRACT_EXPIRY_DATE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COUNTRY_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COUNTRY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
@@ -29,37 +31,45 @@ public class TypicalClients {
 
     public static final Client ALICE = new ClientBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withPhone("94351253").withCountry("SG").withTimezone("GMT+8").withTags("friends").build();
+            .withPhone("94351253").withCountry("SG").withTimezone("GMT+8").withContractExpiryDate("1-4-2021")
+            .withTags("friends").build();
     public static final Client BENSON = new ClientBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25").withCountry("SG").withTimezone("GMT+8")
-            .withEmail("johnd@example.com").withPhone("98765432").withTags("owesMoney", "friends").build();
+            .withEmail("johnd@example.com").withPhone("98765432").withContractExpiryDate("3-12-2022")
+            .withTags("owesMoney", "friends").build();
     public static final Client CARL = new ClientBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street").withCountry("US").withTimezone("GMT-4").build();
+            .withEmail("heinz@example.com").withAddress("wall street").withCountry("US").withTimezone("GMT-4")
+            .withContractExpiryDate("30-1-2022").build();
     public static final Client DANIEL = new ClientBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withAddress("10th street").withCountry("SG")
-            .withTimezone("GMT+8").withTags("friends").build();
+            .withTimezone("GMT+8").withContractExpiryDate("28-2-2021").withTags("friends").build();
     public static final Client ELLE = new ClientBuilder().withName("Elle Meyer").withPhone("9482224")
             .withEmail("werner@example.com").withAddress("michegan ave").withCountry("GB")
-            .withTimezone("GMT+1").build();
+            .withTimezone("GMT+1").withContractExpiryDate("10-10-2024").build();
     public static final Client FIONA = new ClientBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withAddress("little tokyo").withCountry("JP").withTimezone("GMT+9").build();
+            .withEmail("lydia@example.com").withAddress("little tokyo").withCountry("JP").withTimezone("GMT+9")
+            .withContractExpiryDate("9-11-2022").build();
     public static final Client GEORGE = new ClientBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street").withCountry("US").withTimezone("GMT-4").build();
+            .withEmail("anna@example.com").withAddress("4th street").withCountry("US").withTimezone("GMT-4")
+            .withContractExpiryDate("2-8-2021").build();
 
     // Manually added
     public static final Client HOON = new ClientBuilder().withName("Hoon Meier").withPhone("8482424")
             .withEmail("stefan@example.com").withAddress("little india").withCountry("IN")
-            .withTimezone("GMT+5").build();
+            .withTimezone("GMT+5").withContractExpiryDate("23-4-2021").build();
     public static final Client IDA = new ClientBuilder().withName("Ida Mueller").withPhone("8482131")
-            .withEmail("hans@example.com").withAddress("chicago ave").withCountry("US").withTimezone("GMT-4").build();
+            .withEmail("hans@example.com").withAddress("chicago ave").withCountry("US").withTimezone("GMT-4")
+            .withContractExpiryDate("31-12-2020").build();
 
     // Manually added - Client's details found in {@code CommandTestUtil}
     public static final Client AMY = new ClientBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
             .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withCountry(VALID_COUNTRY_AMY)
-            .withTimezone(VALID_TIMEZONE_AMY).withTags(VALID_TAG_FRIEND).build();
+            .withTimezone(VALID_TIMEZONE_AMY).withContractExpiryDate(VALID_CONTRACT_EXPIRY_DATE_AMY)
+            .withTags(VALID_TAG_FRIEND).build();
     public static final Client BOB = new ClientBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withCountry(VALID_COUNTRY_BOB)
-            .withTimezone(VALID_TIMEZONE_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+            .withTimezone(VALID_TIMEZONE_BOB).withContractExpiryDate(VALID_CONTRACT_EXPIRY_DATE_BOB)
+            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 


### PR DESCRIPTION
## Description

Added the new field contractExpiryDate to client

Fixes #172, fixes #190 

## Testing

Ran the following commands:
`client add n/test p/999 e/a@c.com a/testa c/SG tz/GMT+8 ce/1-2-20`
`client edit 1 ce/31-2-2020`  This should give an error
`client edit 1 ce/0-2-2020` This should give an error
`client edit 1 ce/20-1-1` This should give an error
`client edit 1 ce/20-1-10` 

## Remarks

Not sure if we should make this contract expiry date optional? I would suggest we leave it as compulsory for now, then do further changes if we have time.