### PR TITLE
Enable assertions in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ checkstyle {
     toolVersion = '8.29'
 }
 
+run {
+    enableAssertions = true
+}
+
 test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport


### PR DESCRIPTION
## Description

As per title.

## Testing

Testing by running `gradle run` with an assertion that always fails and an assertion that always passes. Works as expected.

## Remarks

NIL