### PR TITLE
Add implementation for suggest available

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SuggestCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SuggestCommand.java
@@ -35,7 +35,6 @@ public class SuggestCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        // TODO: Handle meaningful execution here
         requireNonNull(model);
         model.updateFilteredClientList(
             client -> suggestionTypePredicateList.stream().allMatch(pred -> pred.test(client)));

--- a/src/main/java/seedu/address/logic/commands/SuggestCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SuggestCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUGGEST;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.address.model.Model;
@@ -23,20 +24,20 @@ public class SuggestCommand extends Command {
         + "Example: " + COMMAND_WORD + " " + PREFIX_SUGGEST + SuggestionType.BY_CONTRACT;
     public static final String MESSAGE_SUGGEST_SUCCESS = "Showing clients based on suggestion criteria";
 
-    private final Predicate<Client> combinedSuggestionPredicate;
+    private final List<Predicate<Client>> suggestionTypePredicateList;
 
     /**
      * Initializes SuggestCommand with a SuggestionType
      */
-    public SuggestCommand(Predicate<Client> combinedSuggestionPredicate) {
-        requireNonNull(combinedSuggestionPredicate);
-        this.combinedSuggestionPredicate = combinedSuggestionPredicate;
+    public SuggestCommand(List<Predicate<Client>> suggestionTypePredicateList) {
+        this.suggestionTypePredicateList = suggestionTypePredicateList;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredClientList(combinedSuggestionPredicate);
+        model.updateFilteredClientList(
+            client -> suggestionTypePredicateList.stream().allMatch(pred -> pred.test(client)));
         return new CommandResult(MESSAGE_SUGGEST_SUCCESS);
     }
 
@@ -44,6 +45,6 @@ public class SuggestCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
             || (other instanceof SuggestCommand // instanceof handles nulls
-            && combinedSuggestionPredicate.equals(((SuggestCommand) other).combinedSuggestionPredicate)); // state check
+            && suggestionTypePredicateList.equals(((SuggestCommand) other).suggestionTypePredicateList)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/commands/SuggestCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SuggestCommand.java
@@ -3,9 +3,11 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUGGEST;
 
-import java.util.Set;
+import java.util.List;
+import java.util.function.Predicate;
 
 import seedu.address.model.Model;
+import seedu.address.model.client.Client;
 import seedu.address.model.client.SuggestionType;
 
 /**
@@ -15,34 +17,35 @@ public class SuggestCommand extends Command {
 
     public static final String COMMAND_WORD = "suggest";
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Suggests a list of all clients based on the "
-            + "suggestion types specified in the arguments.\n"
-            + "Parameters: " + PREFIX_SUGGEST + "SUGGESTION_TYPE\n"
-            + "Example: " + COMMAND_WORD + " by/contact\n"
-            + "Example: " + COMMAND_WORD + " by/available\n"
-            + "Example: " + COMMAND_WORD + " by/priority";
+        + "suggestion types specified in the arguments.\n"
+        + "Parameters: " + PREFIX_SUGGEST + "SUGGESTION_TYPE\n"
+        + "Example: " + COMMAND_WORD + " " + PREFIX_SUGGEST + SuggestionType.BY_FREQUENCY + "\n"
+        + "Example: " + COMMAND_WORD + " " + PREFIX_SUGGEST + SuggestionType.BY_AVAILABLE + "\n"
+        + "Example: " + COMMAND_WORD + " " + PREFIX_SUGGEST + SuggestionType.BY_CONTRACT;
     public static final String MESSAGE_SUGGEST_SUCCESS = "Showing clients based on suggestion criteria";
 
-    private final Set<SuggestionType> suggestionTypes;
+    private final List<Predicate<Client>> suggestionTypePredicateList;
 
     /**
      * Initializes SuggestCommand with a SuggestionType
-     * TODO: Modify to handle multiple suggestions
      */
-    public SuggestCommand(Set<SuggestionType> suggestionTypes) {
-        this.suggestionTypes = suggestionTypes;
+    public SuggestCommand(List<Predicate<Client>> suggestionTypePredicateList) {
+        this.suggestionTypePredicateList = suggestionTypePredicateList;
     }
 
     @Override
     public CommandResult execute(Model model) {
         // TODO: Handle meaningful execution here
         requireNonNull(model);
+        model.updateFilteredClientList(
+            client -> suggestionTypePredicateList.stream().allMatch(pred -> pred.test(client)));
         return new CommandResult(MESSAGE_SUGGEST_SUCCESS);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof SuggestCommand // instanceof handles nulls
-                && suggestionTypes.equals(((SuggestCommand) other).suggestionTypes)); // state check
+            || (other instanceof SuggestCommand // instanceof handles nulls
+            && suggestionTypePredicateList.equals(((SuggestCommand) other).suggestionTypePredicateList)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/commands/SuggestCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SuggestCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUGGEST;
 
-import java.util.List;
 import java.util.function.Predicate;
 
 import seedu.address.model.Model;
@@ -24,20 +23,20 @@ public class SuggestCommand extends Command {
         + "Example: " + COMMAND_WORD + " " + PREFIX_SUGGEST + SuggestionType.BY_CONTRACT;
     public static final String MESSAGE_SUGGEST_SUCCESS = "Showing clients based on suggestion criteria";
 
-    private final List<Predicate<Client>> suggestionTypePredicateList;
+    private final Predicate<Client> combinedSuggestionPredicate;
 
     /**
      * Initializes SuggestCommand with a SuggestionType
      */
-    public SuggestCommand(List<Predicate<Client>> suggestionTypePredicateList) {
-        this.suggestionTypePredicateList = suggestionTypePredicateList;
+    public SuggestCommand(Predicate<Client> combinedSuggestionPredicate) {
+        requireNonNull(combinedSuggestionPredicate);
+        this.combinedSuggestionPredicate = combinedSuggestionPredicate;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredClientList(
-            client -> suggestionTypePredicateList.stream().allMatch(pred -> pred.test(client)));
+        model.updateFilteredClientList(combinedSuggestionPredicate);
         return new CommandResult(MESSAGE_SUGGEST_SUCCESS);
     }
 
@@ -45,6 +44,6 @@ public class SuggestCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
             || (other instanceof SuggestCommand // instanceof handles nulls
-            && suggestionTypePredicateList.equals(((SuggestCommand) other).suggestionTypePredicateList)); // state check
+            && combinedSuggestionPredicate.equals(((SuggestCommand) other).combinedSuggestionPredicate)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/parser/SuggestCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SuggestCommandParser.java
@@ -3,10 +3,8 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUGGEST;
 
-import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.SuggestCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -35,11 +33,12 @@ public class SuggestCommandParser implements Parser<SuggestCommand> {
         Set<SuggestionType> suggestionTypeList =
             ParserUtil.parseSuggestionTypes(argMultimap.getAllValues(PREFIX_SUGGEST));
 
-        List<Predicate<Client>> suggestionTypePredicateList = suggestionTypeList.stream()
-            .map(suggestionType -> suggestionType.getSuggestionPredicate()).collect(
-                Collectors.toList());
+        Predicate<Client> combinedSuggestionPredicate = suggestionTypeList
+            .stream()
+            .map(SuggestionType::getSuggestionPredicate)
+            .reduce(client -> true, (x, y) -> client -> x.test(client) && y.test(client));
 
-        return new SuggestCommand(suggestionTypePredicateList);
+        return new SuggestCommand(combinedSuggestionPredicate);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/SuggestCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SuggestCommandParser.java
@@ -3,10 +3,14 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUGGEST;
 
+import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.SuggestCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.client.Client;
 import seedu.address.model.client.SuggestionType;
 
 /**
@@ -21,17 +25,21 @@ public class SuggestCommandParser implements Parser<SuggestCommand> {
      */
     public SuggestCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_SUGGEST);
+            ArgumentTokenizer.tokenize(args, PREFIX_SUGGEST);
 
         if (!argMultimap.getValue(PREFIX_SUGGEST).isPresent()) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SuggestCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SuggestCommand.MESSAGE_USAGE));
         }
 
         Set<SuggestionType> suggestionTypeList =
-                ParserUtil.parseSuggestionTypes(argMultimap.getAllValues(PREFIX_SUGGEST));
+            ParserUtil.parseSuggestionTypes(argMultimap.getAllValues(PREFIX_SUGGEST));
 
-        return new SuggestCommand(suggestionTypeList);
+        List<Predicate<Client>> suggestionTypePredicateList = suggestionTypeList.stream()
+            .map(suggestionType -> suggestionType.getSuggestionPredicate()).collect(
+                Collectors.toList());
+
+        return new SuggestCommand(suggestionTypePredicateList);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/SuggestCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SuggestCommandParser.java
@@ -3,8 +3,10 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_SUGGEST;
 
+import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.SuggestCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -33,12 +35,12 @@ public class SuggestCommandParser implements Parser<SuggestCommand> {
         Set<SuggestionType> suggestionTypeList =
             ParserUtil.parseSuggestionTypes(argMultimap.getAllValues(PREFIX_SUGGEST));
 
-        Predicate<Client> combinedSuggestionPredicate = suggestionTypeList
+        List<Predicate<Client>> suggestionTypePredicateList = suggestionTypeList
             .stream()
-            .map(SuggestionType::getSuggestionPredicate)
-            .reduce(client -> true, (x, y) -> client -> x.test(client) && y.test(client));
+            .map(suggestionType -> suggestionType.getSuggestionPredicate())
+            .collect(Collectors.toList());
 
-        return new SuggestCommand(combinedSuggestionPredicate);
+        return new SuggestCommand(suggestionTypePredicateList);
     }
 
 }

--- a/src/main/java/seedu/address/model/client/SuggestAvailabilityPredicate.java
+++ b/src/main/java/seedu/address/model/client/SuggestAvailabilityPredicate.java
@@ -1,0 +1,18 @@
+package seedu.address.model.client;
+
+import java.util.function.Predicate;
+
+/**
+ * Predicate to check for client availability in their timezone
+ */
+public class SuggestAvailabilityPredicate implements Predicate<Client> {
+    private static final int AVAILABLE_STARTING_HOUR = 18;
+    private static final int AVAILABLE_ENDING_HOUR = 22;
+
+    @Override
+    public boolean test(Client client) {
+        int currHour = client.getTimezone().getCurrHourInTimezone();
+        return (currHour >= AVAILABLE_STARTING_HOUR && currHour <= AVAILABLE_ENDING_HOUR);
+    }
+
+}

--- a/src/main/java/seedu/address/model/client/SuggestAvailabilityPredicate.java
+++ b/src/main/java/seedu/address/model/client/SuggestAvailabilityPredicate.java
@@ -8,6 +8,7 @@ import java.util.function.Predicate;
 public class SuggestAvailabilityPredicate implements Predicate<Client> {
     private static final int AVAILABLE_STARTING_HOUR = 18;
     private static final int AVAILABLE_ENDING_HOUR = 22;
+    private static final int SUGGEST_AVAILABILITY_PREDICATE_HASHCODE = 1;
 
     @Override
     public boolean test(Client client) {
@@ -15,4 +16,14 @@ public class SuggestAvailabilityPredicate implements Predicate<Client> {
         return (currHour >= AVAILABLE_STARTING_HOUR && currHour < AVAILABLE_ENDING_HOUR);
     }
 
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof SuggestAvailabilityPredicate); // instanceof handles nulls
+    }
+
+    @Override
+    public int hashCode() {
+        return SUGGEST_AVAILABILITY_PREDICATE_HASHCODE;
+    }
 }

--- a/src/main/java/seedu/address/model/client/SuggestAvailabilityPredicate.java
+++ b/src/main/java/seedu/address/model/client/SuggestAvailabilityPredicate.java
@@ -12,7 +12,7 @@ public class SuggestAvailabilityPredicate implements Predicate<Client> {
     @Override
     public boolean test(Client client) {
         int currHour = client.getTimezone().getCurrHourInTimezone();
-        return (currHour >= AVAILABLE_STARTING_HOUR && currHour <= AVAILABLE_ENDING_HOUR);
+        return (currHour >= AVAILABLE_STARTING_HOUR && currHour < AVAILABLE_ENDING_HOUR);
     }
 
 }

--- a/src/main/java/seedu/address/model/client/SuggestionType.java
+++ b/src/main/java/seedu/address/model/client/SuggestionType.java
@@ -3,6 +3,8 @@ package seedu.address.model.client;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.function.Predicate;
+
 /**
  * Represents a SuggestionType in the address book.
  * Guarantees: immutable; suggestion type is valid as declared in {@link #isValidSuggestionType(String)}
@@ -12,8 +14,8 @@ public class SuggestionType {
     public static final String BY_FREQUENCY = "frequency";
     public static final String BY_AVAILABLE = "available";
     public static final String BY_CONTRACT = "contract";
-    public static final String MESSAGE_CONSTRAINTS = "Suggestion type can only be of the following "
-        + BY_FREQUENCY + " " + BY_AVAILABLE + " " + BY_CONTRACT;
+    public static final String MESSAGE_CONSTRAINTS = "Suggestion type can only be of the following: "
+        + BY_FREQUENCY + ", " + BY_AVAILABLE + ", " + BY_CONTRACT;
 
     public final String suggestionString;
 
@@ -26,6 +28,21 @@ public class SuggestionType {
         requireNonNull(suggestionString);
         checkArgument(isValidSuggestionType(suggestionString), MESSAGE_CONSTRAINTS);
         this.suggestionString = suggestionString;
+    }
+
+    public Predicate<Client> getSuggestionPredicate() {
+        switch (suggestionString) {
+        case BY_AVAILABLE:
+            return new SuggestAvailabilityPredicate();
+        case BY_CONTRACT:
+            break;
+        case BY_FREQUENCY:
+            break;
+        default:
+        }
+
+        assert false; // code execution will never reach here
+        return null;
     }
 
     /**

--- a/src/main/java/seedu/address/model/client/SuggestionType.java
+++ b/src/main/java/seedu/address/model/client/SuggestionType.java
@@ -35,9 +35,9 @@ public class SuggestionType {
         case BY_AVAILABLE:
             return new SuggestAvailabilityPredicate();
         case BY_CONTRACT:
-            break;
+            return client -> true;
         case BY_FREQUENCY:
-            break;
+            return client -> true;
         default:
         }
 

--- a/src/main/java/seedu/address/model/client/SuggestionType.java
+++ b/src/main/java/seedu/address/model/client/SuggestionType.java
@@ -39,10 +39,9 @@ public class SuggestionType {
         case BY_FREQUENCY:
             return client -> true;
         default:
+            assert false; // code execution will never reach here
+            return null;
         }
-
-        assert false; // code execution will never reach here
-        return null;
     }
 
     /**

--- a/src/main/java/seedu/address/model/client/Timezone.java
+++ b/src/main/java/seedu/address/model/client/Timezone.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+
 /**
  * Represents a Client's timezone in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidTimezone(String)}
@@ -25,6 +26,7 @@ public class Timezone {
     private static final int LARGEST_POSITIVE_OFFSET = 14;
 
     public final String value;
+    public final int timezoneOffset;
 
     /**
      * Constructs a {@code Timezone}.
@@ -35,6 +37,22 @@ public class Timezone {
         requireNonNull(timezone);
         checkArgument(isValidTimezone(timezone), MESSAGE_CONSTRAINTS);
         value = timezone;
+        timezoneOffset = extractTimezoneOffset(timezone);
+    }
+
+    private static int extractTimezoneOffset(String test) {
+        final Matcher matcher = TIMEZONE_FORMAT.matcher(test);
+        matcher.find();
+
+        final String numberString = matcher.group("number");
+        return Integer.parseInt(numberString);
+    }
+
+    private static String extractSign(String test) {
+        final Matcher matcher = TIMEZONE_FORMAT.matcher(test);
+        matcher.find();
+
+        return matcher.group("sign");
     }
 
     /**
@@ -57,6 +75,30 @@ public class Timezone {
             }
         }
         return false;
+    }
+
+    /**
+     * Gets the current hour in this timezone.
+     * Code adapted from https://www.w3resource.com/java-exercises/datatypes/java-datatype-exercise-5.php
+     *
+     * @return The current hour in this timezone.
+     */
+    public int getCurrHourInTimezone() {
+        long totalMilliseconds = System.currentTimeMillis();
+
+        long totalSeconds = totalMilliseconds / 1000;
+
+        long currentSecond = totalSeconds % 60;
+
+        long totalMinutes = totalSeconds / 60;
+
+        long currentMinute = totalMinutes % 60;
+
+        long totalHours = totalMinutes / 60;
+
+        long currentHour = ((totalHours + timezoneOffset) % 24);
+
+        return (int) currentHour;
     }
 
 

--- a/src/main/java/seedu/address/model/client/Timezone.java
+++ b/src/main/java/seedu/address/model/client/Timezone.java
@@ -3,8 +3,8 @@ package seedu.address.model.client;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
-import java.util.Calendar;
-import java.util.TimeZone;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -15,17 +15,21 @@ import java.util.regex.Pattern;
  */
 public class Timezone {
 
+    public static final String GMT_STRING = "GMT";
+    public static final int SMALLEST_NEGATIVE_OFFSET = 12;
+    public static final int LARGEST_POSITIVE_OFFSET = 14;
+
     public static final String MESSAGE_CONSTRAINTS =
-            "Timezone should be in the form \"GMT+X\" or \"GMT-X\" where X is a number.\n"
-            + "Largest offset is GMT+14 and smallest offset is GMT-12";
+        "Timezone should be in the form \"" + GMT_STRING + "+X\" or \"" + GMT_STRING
+            + "-X\" where X is a number.\n" + "Largest offset is " + GMT_STRING
+            + "+" + LARGEST_POSITIVE_OFFSET + " and smallest offset is " + GMT_STRING
+            + "-" + SMALLEST_NEGATIVE_OFFSET;
 
     /** Timezone must start with "GMT" */
-    public static final String VALIDATION_REGEX = "^GMT(?<sign>[+-])(?<number>[\\d]+)";
+    public static final String VALIDATION_REGEX = "^" + GMT_STRING + "(?<sign>[+-])(?<number>[\\d]+)";
 
     private static final Pattern TIMEZONE_FORMAT = Pattern.compile(VALIDATION_REGEX);
 
-    private static final int SMALLEST_NEGATIVE_OFFSET = 12;
-    private static final int LARGEST_POSITIVE_OFFSET = 14;
 
     public final String value;
 
@@ -68,10 +72,10 @@ public class Timezone {
      * @return The current hour in this timezone.
      */
     public int getCurrHourInTimezone() {
-        TimeZone tz = TimeZone.getTimeZone(value);
-        Calendar calendar = Calendar.getInstance(tz);
-
-        return calendar.get(Calendar.HOUR_OF_DAY);
+        String offsetString = value.substring(GMT_STRING.length());
+        ZoneOffset zoneOffSet = ZoneOffset.of(offsetString);
+        OffsetDateTime date = OffsetDateTime.now(zoneOffSet);
+        return date.getHour();
     }
 
 

--- a/src/main/java/seedu/address/model/client/Timezone.java
+++ b/src/main/java/seedu/address/model/client/Timezone.java
@@ -3,6 +3,8 @@ package seedu.address.model.client;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
+import java.util.Calendar;
+import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -26,7 +28,6 @@ public class Timezone {
     private static final int LARGEST_POSITIVE_OFFSET = 14;
 
     public final String value;
-    public final int timezoneOffset;
 
     /**
      * Constructs a {@code Timezone}.
@@ -37,22 +38,6 @@ public class Timezone {
         requireNonNull(timezone);
         checkArgument(isValidTimezone(timezone), MESSAGE_CONSTRAINTS);
         value = timezone;
-        timezoneOffset = extractTimezoneOffset(timezone);
-    }
-
-    private static int extractTimezoneOffset(String test) {
-        final Matcher matcher = TIMEZONE_FORMAT.matcher(test);
-        matcher.find();
-
-        final String numberString = matcher.group("number");
-        return Integer.parseInt(numberString);
-    }
-
-    private static String extractSign(String test) {
-        final Matcher matcher = TIMEZONE_FORMAT.matcher(test);
-        matcher.find();
-
-        return matcher.group("sign");
     }
 
     /**
@@ -79,26 +64,14 @@ public class Timezone {
 
     /**
      * Gets the current hour in this timezone.
-     * Code adapted from https://www.w3resource.com/java-exercises/datatypes/java-datatype-exercise-5.php
      *
      * @return The current hour in this timezone.
      */
     public int getCurrHourInTimezone() {
-        long totalMilliseconds = System.currentTimeMillis();
+        TimeZone tz = TimeZone.getTimeZone(value);
+        Calendar calendar = Calendar.getInstance(tz);
 
-        long totalSeconds = totalMilliseconds / 1000;
-
-        long currentSecond = totalSeconds % 60;
-
-        long totalMinutes = totalSeconds / 60;
-
-        long currentMinute = totalMinutes % 60;
-
-        long totalHours = totalMinutes / 60;
-
-        long currentHour = ((totalHours + timezoneOffset) % 24);
-
-        return (int) currentHour;
+        return calendar.get(Calendar.HOUR_OF_DAY);
     }
 
 

--- a/src/test/java/seedu/address/model/client/SuggestAvailabilityPredicateTest.java
+++ b/src/test/java/seedu/address/model/client/SuggestAvailabilityPredicateTest.java
@@ -1,0 +1,58 @@
+package seedu.address.model.client;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.ClientBuilder;
+
+public class SuggestAvailabilityPredicateTest {
+
+    @Test
+    public void test_clientAt17_false() {
+        TimezoneStub fivePm = new TimezoneStub("GMT+8", 17);
+        Client client = new ClientBuilder().withTimezone(fivePm).build();
+        SuggestAvailabilityPredicate suggestAvailabilityPredicate = new SuggestAvailabilityPredicate();
+        assertFalse(suggestAvailabilityPredicate.test(client));
+    }
+
+    @Test
+    public void test_clientAt18_true() {
+        TimezoneStub sixPm = new TimezoneStub("GMT+8", 18);
+        Client client = new ClientBuilder().withTimezone(sixPm).build();
+        SuggestAvailabilityPredicate suggestAvailabilityPredicate = new SuggestAvailabilityPredicate();
+        assertTrue(suggestAvailabilityPredicate.test(client));
+    }
+
+    @Test
+    public void test_clientAt21_true() {
+        TimezoneStub tenPm = new TimezoneStub("GMT+8", 21);
+        Client client = new ClientBuilder().withTimezone(tenPm).build();
+        SuggestAvailabilityPredicate suggestAvailabilityPredicate = new SuggestAvailabilityPredicate();
+        assertTrue(suggestAvailabilityPredicate.test(client));
+    }
+
+    @Test
+    public void test_clientAt22_false() {
+        TimezoneStub elevenPm = new TimezoneStub("GMT+8", 22);
+        Client client = new ClientBuilder().withTimezone(elevenPm).build();
+        SuggestAvailabilityPredicate suggestAvailabilityPredicate = new SuggestAvailabilityPredicate();
+        assertFalse(suggestAvailabilityPredicate.test(client));
+    }
+
+
+    private static class TimezoneStub extends Timezone {
+        private final int testCurrHour;
+
+        TimezoneStub(String val, int testCurrHour) {
+            super(val);
+            this.testCurrHour = testCurrHour;
+        }
+
+        @Override
+        public int getCurrHourInTimezone() {
+            return testCurrHour;
+        }
+    }
+}

--- a/src/test/java/seedu/address/model/client/SuggestionTypeTest.java
+++ b/src/test/java/seedu/address/model/client/SuggestionTypeTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 public class SuggestionTypeTest {
+
     @Test
     public void getSuggestionPredicate_byAvailable_suggestAvailabilityPredicate() {
         SuggestionType available = new SuggestionType(SuggestionType.BY_AVAILABLE);

--- a/src/test/java/seedu/address/model/client/SuggestionTypeTest.java
+++ b/src/test/java/seedu/address/model/client/SuggestionTypeTest.java
@@ -1,0 +1,14 @@
+package seedu.address.model.client;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class SuggestionTypeTest {
+    @Test
+    public void getSuggestionPredicate_byAvailable_suggestAvailabilityPredicate() {
+        SuggestionType available = new SuggestionType(SuggestionType.BY_AVAILABLE);
+        assertTrue(available.getSuggestionPredicate() instanceof SuggestAvailabilityPredicate);
+    }
+
+}

--- a/src/test/java/seedu/address/model/client/TimezoneTest.java
+++ b/src/test/java/seedu/address/model/client/TimezoneTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -38,5 +39,24 @@ public class TimezoneTest {
         assertTrue(Timezone.isValidTimezone("GMT-12")); // smallest negative offset
         assertTrue(Timezone.isValidTimezone("GMT+14")); // largest positive offset
 
+    }
+
+    @Test
+    public void getCurrHourInTimezone() {
+        // use System clock to test
+        // adapted from https://www.w3resource.com/java-exercises/datatypes/java-datatype-exercise-5.php
+        for (int timezoneOffset = -1 * Timezone.SMALLEST_NEGATIVE_OFFSET;
+            timezoneOffset <= Timezone.LARGEST_POSITIVE_OFFSET; timezoneOffset++) {
+            long totalMilliseconds = System.currentTimeMillis();
+            long totalSeconds = totalMilliseconds / 1000;
+            long currentSecond = totalSeconds % 60;
+            long totalMinutes = totalSeconds / 60;
+            long currentMinute = totalMinutes % 60;
+            long totalHours = totalMinutes / 60;
+            long currentHour = ((totalHours + timezoneOffset) % 24);
+
+            String value = "GMT" + (timezoneOffset >= 0 ? "+" : "") + timezoneOffset;
+            assertEquals(currentHour, new Timezone(value).getCurrHourInTimezone());
+        }
     }
 }

--- a/src/test/java/seedu/address/testutil/ClientBuilder.java
+++ b/src/test/java/seedu/address/testutil/ClientBuilder.java
@@ -121,6 +121,14 @@ public class ClientBuilder {
     }
 
     /**
+     * Sets the {@code Timezone} of the {@code Client} that we are building.
+     */
+    public ClientBuilder withTimezone(Timezone timezone) {
+        this.timezone = timezone;
+        return this;
+    }
+
+    /**
      * Sets the {@code ContractExpiryDate} of the {@code Client} that we are building.
      */
     public ClientBuilder withContractExpiryDate(String contractExpiryDate) {


### PR DESCRIPTION
## Description

- `SuggestCommand` to take in a list of predicates of client.
- `SuggestionType` to have a `getSuggestionPredicate` method
- Add `SuggestAvailabilityPredicate` to filter based on the client local time (6pm - 10pm)
- Add `getCurrHourInTimezone` method in `Timezone`

Fixes #169 

## Testing

- Tested using a TimezoneStub with hardcoded return values for 6pm <= `getCurrHourInTimezone` < 10pm.
- Tested `getCurrHourInTimezone` with traditional method using system clock. (Ref: https://www.w3resource.com/java-exercises/datatypes/java-datatype-exercise-5.php)

## Remarks

Used https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/ZoneOffset.html to find current time based on GMT timezone.
