### PR TITLE
Refactor to standardized parsing format

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClientNoteAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientNoteAddCommand.java
@@ -26,7 +26,7 @@ public class ClientNoteAddCommand extends Command {
             + "by the index number used in the displayed client list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX " + PREFIX_NOTE + "NOTE_STRING [" + PREFIX_TAG + "TAG]...\n"
-            + "Example: " + COMMAND_WORD + " 1 " + "client note content";
+            + "Example: " + COMMAND_WORD + " 1 " + PREFIX_NOTE + "client note content";
     private static final String MESSAGE_DUPLICATE_CLIENT_NOTE = "The client note already exists";
     private static final String MESSAGE_SUCCESS = "Successfully added client note";
     private final Index targetIndex;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -189,5 +189,4 @@ public class AddressBookParser {
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
     }
-
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
-import java.util.StringTokenizer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -34,12 +34,12 @@ public class AddressBookParser {
      */
     private static final String CLIENT_TYPE = "client";
     private static final String COUNTRY_TYPE = "country";
+    private static final String NOTE_TYPE = "note";
 
     /**
-     * Used for initial separation of command type and rest of command.
+     * Used for separation of command type and rest of command.
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandType>\\S+)(?<restOfCommand>.*)");
-    private static final Pattern SECONDARY_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
 
     private final TagNoteMap tagNoteMap;
 
@@ -98,22 +98,22 @@ public class AddressBookParser {
      * @throws ParseException if input does not conform to expected format
      */
     private Command parseCountryCommands(String input) throws ParseException {
-        final Matcher secondaryMatcher = SECONDARY_COMMAND_FORMAT.matcher(input.trim());
-        if (!secondaryMatcher.matches()) {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(input.trim());
+        if (!matcher.matches()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
-        String commandWord = secondaryMatcher.group("commandWord");
-        final String arguments = secondaryMatcher.group("arguments");
+        final String commandType = matcher.group("commandType");
+        final String restOfCommand = matcher.group("restOfCommand");
 
-        commandWord = COUNTRY_TYPE + " " + commandWord;
+        String commandWord = COUNTRY_TYPE + " " + commandType;
         switch (commandWord) {
         case CountryNoteCommand.COMMAND_WORD:
-            return new CountryNoteCommandParser().parse(arguments);
+            return new CountryNoteCommandParser().parse(restOfCommand);
 
         case CountryFilterCommand.COMMAND_WORD:
-            return new CountryFilterCommandParser().parse(arguments);
+            return new CountryFilterCommandParser().parse(restOfCommand);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
@@ -128,46 +128,63 @@ public class AddressBookParser {
      * @throws ParseException if input does not conform to expected format
      */
     private Command parseClientCommands(String input) throws ParseException {
-        final Matcher secondaryMatcher = SECONDARY_COMMAND_FORMAT.matcher(input.trim());
-        if (!secondaryMatcher.matches()) {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(input.trim());
+        if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
-        String commandWord = secondaryMatcher.group("commandWord");
-        String arguments = secondaryMatcher.group("arguments");
-        commandWord = CLIENT_TYPE + " " + commandWord;
-        // todo: abstract away this parsing logic or use better regex matcher
-        StringTokenizer stringTokenizer = new StringTokenizer(arguments);
-        String nextWord = stringTokenizer.nextToken();
-        if (nextWord.equals("add")) {
-            // gather rest of the arguments:
-            StringBuilder stringBuilder = new StringBuilder();
-            while (stringTokenizer.hasMoreTokens()) {
-                stringBuilder.append(stringTokenizer.nextToken()).append(" ");
-            }
+        final String commandType = matcher.group("commandType");
+        final String restOfCommand = matcher.group("restOfCommand");
 
-            commandWord += (" " + nextWord);
-            arguments = " " + stringBuilder.toString();
+        if (commandType.equals(NOTE_TYPE)) {
+            return parseClientNoteCommands(restOfCommand);
         }
+
+        String commandWord = CLIENT_TYPE + " " + commandType;
+
+        switch (commandWord) {
+        case ClientAddCommand.COMMAND_WORD:
+            return new ClientAddCommandParser().parse(restOfCommand);
+
+        case ClientEditCommand.COMMAND_WORD:
+            return new ClientEditCommandParser().parse(restOfCommand);
+
+        case ClientDeleteCommand.COMMAND_WORD:
+            return new ClientDeleteCommandParser().parse(restOfCommand);
+
+        case ClientFindCommand.COMMAND_WORD:
+            return new ClientFindCommandParser().parse(restOfCommand);
+
+        case ClientViewCommand.COMMAND_WORD:
+            return new ClientViewCommandParser().parse(restOfCommand);
+
+        default:
+            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        }
+    }
+
+    /**
+     * Parses input given that command is of CLIENT_TYPE + NOTE_TYPE (starts with "client note")
+     *
+     * @param input user input with "client note" stripped
+     * @return command relating to client note functions
+     * @throws ParseException if input does not conform to expected format
+     */
+    private Command parseClientNoteCommands(String input) throws ParseException {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(input.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+
+        final String commandType = matcher.group("commandType");
+        final String restOfCommand = matcher.group("restOfCommand");
+
+        String commandWord = CLIENT_TYPE + " " + NOTE_TYPE + " " + commandType;
 
         switch (commandWord) {
         case ClientNoteAddCommand.COMMAND_WORD:
-            return new ClientNoteAddCommandParser(tagNoteMap).parse(arguments);
-
-        case ClientAddCommand.COMMAND_WORD:
-            return new ClientAddCommandParser().parse(arguments);
-
-        case ClientEditCommand.COMMAND_WORD:
-            return new ClientEditCommandParser().parse(arguments);
-
-        case ClientDeleteCommand.COMMAND_WORD:
-            return new ClientDeleteCommandParser().parse(arguments);
-
-        case ClientFindCommand.COMMAND_WORD:
-            return new ClientFindCommandParser().parse(arguments);
-
-        case ClientViewCommand.COMMAND_WORD:
-            return new ClientViewCommandParser().parse(arguments);
+            return new ClientNoteAddCommandParser(tagNoteMap).parse(restOfCommand);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -88,6 +88,8 @@ public class AddressBookParserTest {
     @Test
     public void parseClientCommands_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                HelpCommand.MESSAGE_USAGE), () -> parser.parseCommand("client"));
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 HelpCommand.MESSAGE_USAGE), () -> parser.parseCommand("client "));
     }
 
@@ -95,6 +97,8 @@ public class AddressBookParserTest {
     public void parseClientCommands_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () ->
                 parser.parseCommand("client unknownCommand"));
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () ->
+                parser.parseCommand("client unknownCommand "));
     }
 
     @Test
@@ -120,6 +124,8 @@ public class AddressBookParserTest {
     @Test
     public void parseCountryCommands_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                HelpCommand.MESSAGE_USAGE), () -> parser.parseCommand("country"));
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 HelpCommand.MESSAGE_USAGE), () -> parser.parseCommand("country "));
     }
 
@@ -127,6 +133,8 @@ public class AddressBookParserTest {
     public void parseCountryCommands_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () ->
                 parser.parseCommand("country unknownCommand"));
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () ->
+                parser.parseCommand("country unknownCommand "));
     }
 
     @Test
@@ -145,6 +153,8 @@ public class AddressBookParserTest {
     @Test
     public void parseClientNoteCommands_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                HelpCommand.MESSAGE_USAGE), () -> parser.parseCommand("client note"));
+        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 HelpCommand.MESSAGE_USAGE), () -> parser.parseCommand("client note "));
     }
 
@@ -152,8 +162,9 @@ public class AddressBookParserTest {
     public void parseClientNoteCommands_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () ->
                 parser.parseCommand("client note unknownCommand"));
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () ->
+                parser.parseCommand("client note unknownCommand "));
     }
-
 
     @Test
     public void parseCommand_clear() throws Exception {
@@ -189,10 +200,4 @@ public class AddressBookParserTest {
     public void parseCommand_unknownCommand_throwsParseException() {
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
     }
-
-
-
-
-
-
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -6,7 +6,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNTRY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_CLIENT;
 


### PR DESCRIPTION
## Description

Changed previous implementation of parsing for `client note` commands to use the same regex.

Fixes #200 

## Testing

Commands starting with `client COMMAND` should not throw `InvocationError` anymore.


