### PR TITLE
UI bug fix

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -362,7 +362,7 @@
 
 #clientListView {
     -fx-background-radius: 5, 5;
-    -fx-padding: 0 0 0 17;
+    -fx-padding: 0 0 0 0;
 }
 
 #clientListView .scroll-bar .thumb {

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -362,7 +362,6 @@
 
 #clientListView {
     -fx-background-radius: 5, 5;
-    -fx-padding: 0 0 0 0;
 }
 
 #clientListView .scroll-bar .thumb {

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -47,14 +47,14 @@
                 </StackPane>
 
         <HBox VBox.vgrow="ALWAYS" >
-          <VBox styleClass="pane-with-border" prefWidth="340" VBox.vgrow="ALWAYS" HBox.hgrow="NEVER">
+          <VBox styleClass="pane-with-border" prefHeight="340" prefWidth="340" VBox.vgrow="ALWAYS" HBox.hgrow="NEVER">
             <padding>
               <Insets top="10" right="10" bottom="10" left="10"/>
             </padding>
             <StackPane fx:id="widgetPlaceholder" VBox.vgrow="ALWAYS"/>
           </VBox>
 
-          <VBox fx:id="clientList" styleClass="pane-with-border" minWidth="350" minHeight="300" prefWidth="340" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
+          <VBox fx:id="clientList" styleClass="pane-with-border" prefHeight="340" prefWidth="340" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
             <padding>
               <Insets top="10" right="10" bottom="10" left="10"/>
             </padding>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -46,27 +46,6 @@
                     </padding>
                 </StackPane>
 
-<<<<<<< Updated upstream
-                <HBox VBox.vgrow="ALWAYS">
-                    <VBox styleClass="pane-with-border" prefWidth="340" VBox.vgrow="ALWAYS" HBox.hgrow="NEVER">
-                        <padding>
-                            <Insets top="10" right="10" bottom="10" left="10"/>
-                        </padding>
-                        <StackPane fx:id="widgetPlaceholder" VBox.vgrow="ALWAYS"/>
-                    </VBox>
-                    <VBox fx:id="clientList" styleClass="pane-with-border" minWidth="350" prefWidth="340"
-                          VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
-                        <padding>
-                            <Insets top="10" right="10" bottom="10" left="10"/>
-                        </padding>
-                        <StackPane fx:id="clientListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-                    </VBox>
-                </HBox>
-                <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER"/>
-            </VBox>
-        </Scene>
-    </scene>
-=======
         <HBox VBox.vgrow="ALWAYS" >
           <VBox styleClass="pane-with-border" prefWidth="340" VBox.vgrow="ALWAYS" HBox.hgrow="NEVER">
             <padding>
@@ -86,5 +65,4 @@
       </VBox>
     </Scene>
   </scene>
->>>>>>> Stashed changes
 </fx:root>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -46,6 +46,7 @@
                     </padding>
                 </StackPane>
 
+<<<<<<< Updated upstream
                 <HBox VBox.vgrow="ALWAYS">
                     <VBox styleClass="pane-with-border" prefWidth="340" VBox.vgrow="ALWAYS" HBox.hgrow="NEVER">
                         <padding>
@@ -65,4 +66,25 @@
             </VBox>
         </Scene>
     </scene>
+=======
+        <HBox VBox.vgrow="ALWAYS" >
+          <VBox styleClass="pane-with-border" prefWidth="340" VBox.vgrow="ALWAYS" HBox.hgrow="NEVER">
+            <padding>
+              <Insets top="10" right="10" bottom="10" left="10"/>
+            </padding>
+            <StackPane fx:id="widgetPlaceholder" VBox.vgrow="ALWAYS"/>
+          </VBox>
+
+          <VBox fx:id="clientList" styleClass="pane-with-border" minWidth="350" minHeight="300" prefWidth="340" VBox.vgrow="ALWAYS" HBox.hgrow="ALWAYS">
+            <padding>
+              <Insets top="10" right="10" bottom="10" left="10"/>
+            </padding>
+            <StackPane fx:id="clientListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+          </VBox>
+        </HBox>
+        <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER"/>
+      </VBox>
+    </Scene>
+  </scene>
+>>>>>>> Stashed changes
 </fx:root>


### PR DESCRIPTION
## Description

Remove redundant padding and made the

![image](https://user-images.githubusercontent.com/69501134/96997175-d71ed600-1563-11eb-8126-031224382412.png)

## Testing

NIL

## Remarks

The left side of the list will be thinner than the right side due to the removal of the additional padding.
Padding was added when the scrollbar was removed to make it lol symmetrical.
