### PR TITLE
Add LastModifiedInstant as field in Client

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClientEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientEditCommand.java
@@ -25,6 +25,7 @@ import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
 import seedu.address.model.client.ContractExpiryDate;
 import seedu.address.model.client.Email;
+import seedu.address.model.client.LastModifiedInstant;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
 import seedu.address.model.client.Timezone;
@@ -109,10 +110,11 @@ public class ClientEditCommand extends Command {
         Timezone updatedTimezone = editClientDescriptor.getTimezone().orElse(clientToEdit.getTimezone());
         ContractExpiryDate updatedContractExpiryDate =
                 editClientDescriptor.getContractExpiryDate().orElse(clientToEdit.getContractExpiryDate());
+        LastModifiedInstant updatedLastModifiedInstant = new LastModifiedInstant();
         Set<Tag> updatedTags = editClientDescriptor.getTags().orElse(clientToEdit.getTags());
 
         return new Client(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedCountry, updatedTimezone,
-                updatedContractExpiryDate, updatedTags);
+                updatedContractExpiryDate, updatedLastModifiedInstant, updatedTags);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/ClientAddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ClientAddCommandParser.java
@@ -19,6 +19,7 @@ import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
 import seedu.address.model.client.ContractExpiryDate;
 import seedu.address.model.client.Email;
+import seedu.address.model.client.LastModifiedInstant;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
 import seedu.address.model.client.Timezone;
@@ -53,9 +54,11 @@ public class ClientAddCommandParser implements Parser<ClientAddCommand> {
         Timezone timezone = ParserUtil.parseTimezone(argMultimap.getValue(PREFIX_TIMEZONE).get());
         ContractExpiryDate contractExpiryDate =
                 ParserUtil.parseContractExpiryDate(argMultimap.getValue(PREFIX_CONTRACT_EXPIRY_DATE).get());
+        LastModifiedInstant lastModifiedInstant = new LastModifiedInstant();
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Client client = new Client(name, phone, email, address, country, timezone, contractExpiryDate, tagList);
+        Client client = new Client(name, phone, email, address, country, timezone, contractExpiryDate,
+                lastModifiedInstant, tagList);
 
         return new ClientAddCommand(client);
     }

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -31,12 +31,13 @@ public class Client {
     private final ContractExpiryDate contractExpiryDate;
     private final Set<Tag> tags = new HashSet<>();
     private final Set<Note> clientNotes = new LinkedHashSet<>(); // todo: initialise this iff client has notes
+    private final LastModifiedInstant lastModifiedInstant;
 
     /**
      * Every field must be present and not null.
      */
     public Client(Name name, Phone phone, Email email, Address address, Country country, Timezone timezone,
-            ContractExpiryDate contractExpiryDate, Set<Tag> tags) {
+            ContractExpiryDate contractExpiryDate, LastModifiedInstant lastModifiedInstant, Set<Tag> tags) {
         requireAllNonNull(name, phone, email, address, country, timezone, contractExpiryDate, tags);
         this.name = name;
         this.phone = phone;
@@ -45,6 +46,7 @@ public class Client {
         this.country = country;
         this.timezone = timezone;
         this.contractExpiryDate = contractExpiryDate;
+        this.lastModifiedInstant = lastModifiedInstant;
         this.tags.addAll(tags);
     }
 
@@ -74,6 +76,10 @@ public class Client {
 
     public ContractExpiryDate getContractExpiryDate() {
         return contractExpiryDate;
+    }
+
+    public LastModifiedInstant getLastModifiedInstant() {
+        return lastModifiedInstant;
     }
 
     /**

--- a/src/main/java/seedu/address/model/client/LastModifiedInstant.java
+++ b/src/main/java/seedu/address/model/client/LastModifiedInstant.java
@@ -1,0 +1,73 @@
+package seedu.address.model.client;
+
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+import static java.util.Objects.requireNonNull;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Represents the instant the client was modified.
+ * Guarantees: immutable; is valid as declared in {@link #isValidInstant(String)}
+ */
+public class LastModifiedInstant implements Comparable<LastModifiedInstant> {
+
+    public final Instant value;
+
+    /**
+     * Constructs an {@code LastModifiedInstant}.
+     * This is used when client is added or edited.
+     */
+    public LastModifiedInstant() {
+        this.value = Instant.now();
+    }
+
+    /**
+     * Constructs an {@code LastModifiedInstant}.
+     * This is mainly used to construct an instant from storage.
+     *
+     * @param instant A valid instant string.
+     */
+    public LastModifiedInstant(String instant) {
+        requireNonNull(instant);
+        if (!isValidInstant(instant)) {
+            this.value = Instant.now();
+        } else {
+            this.value = Instant.parse(instant);
+        }
+    }
+
+    /**
+     * Returns true if the String is a valid instant.
+     */
+    public static boolean isValidInstant(String test) {
+        try {
+            Instant.parse(test);
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof LastModifiedInstant // instanceof handles nulls
+                && value.equals(((LastModifiedInstant) other).value)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return ISO_INSTANT.format(value);
+    }
+
+    @Override
+    public int compareTo(LastModifiedInstant other) {
+        return value.compareTo(other.value);
+    }
+}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -11,6 +11,7 @@ import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
 import seedu.address.model.client.ContractExpiryDate;
 import seedu.address.model.client.Email;
+import seedu.address.model.client.LastModifiedInstant;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
 import seedu.address.model.client.Timezone;
@@ -28,25 +29,28 @@ public class SampleDataUtil {
         return new Client[]{
             new Client(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"), new Country("SG"), new Timezone("GMT+8"),
-                new ContractExpiryDate("21-4-2022"), getTagSet("friends")),
+                new ContractExpiryDate("21-4-2022"), new LastModifiedInstant("2020-01-01T00:00:00.000000Z"),
+                    getTagSet("friends")),
             new Client(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new Country("SG"),
                 new Timezone("GMT+8"), new ContractExpiryDate("12-12-2021"),
-                getTagSet("colleagues", "friends")),
+                new LastModifiedInstant("2020-02-02T00:00:00.000000Z"), getTagSet("colleagues", "friends")),
             new Client(new Name("Charlotte Oliveiro"), new Phone("93210283"),
-                new Email("charlotte@example.com"),
-                new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new Country("SG"), new Timezone("GMT+8"),
-                new ContractExpiryDate("1-4-2023"), getTagSet("neighbours")),
+                new Email("charlotte@example.com"), new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
+                new Country("SG"), new Timezone("GMT+8"), new ContractExpiryDate("1-4-2023"),
+                new LastModifiedInstant("2020-03-03T00:00:00.000000Z"), getTagSet("neighbours")),
             new Client(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new Country("SG"),
                 new Timezone("GMT+8"), new ContractExpiryDate("23-12-2020"),
-                getTagSet("family")),
+                new LastModifiedInstant("2020-04-04T00:00:00.000000Z"), getTagSet("family")),
             new Client(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"), new Country("SG"), new Timezone("GMT+8"),
-                new ContractExpiryDate("3-2-2021"), getTagSet("classmates")),
+                new ContractExpiryDate("3-2-2021"), new LastModifiedInstant("2020-05-05T00:00:00.000000Z"),
+                getTagSet("classmates")),
             new Client(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"), new Country("SG"), new Timezone("GMT+8"),
-                new ContractExpiryDate("9-6-2024"), getTagSet("colleagues"))
+                new ContractExpiryDate("9-6-2024"), new LastModifiedInstant("2020-06-06T00:00:00.000000Z"),
+                getTagSet("colleagues"))
         };
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedClient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedClient.java
@@ -148,6 +148,9 @@ class JsonAdaptedClient {
         final ContractExpiryDate modelContractExpiryContractExpiryDate =
                 ParserUtil.parseContractExpiryDate(contractExpiryDate);
 
+        // Does not throw an exception if lastModifiedInstant is missing/invalid due to corruption of data.
+        // This field is merely metadata for us and is not significant enough to discard client's data due to this
+        // field being missing.
         LastModifiedInstant modelLastModifiedInstant;
         if (lastModifiedInstant == null) {
             modelLastModifiedInstant = new LastModifiedInstant();

--- a/src/main/java/seedu/address/storage/JsonAdaptedClient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedClient.java
@@ -15,6 +15,7 @@ import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
 import seedu.address.model.client.ContractExpiryDate;
 import seedu.address.model.client.Email;
+import seedu.address.model.client.LastModifiedInstant;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
 import seedu.address.model.client.Timezone;
@@ -36,6 +37,7 @@ class JsonAdaptedClient {
     private final String country;
     private final String timezone;
     private final String contractExpiryDate;
+    private final String lastModifiedInstant;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
 
     /**
@@ -46,6 +48,7 @@ class JsonAdaptedClient {
             @JsonProperty("email") String email, @JsonProperty("address") String address,
             @JsonProperty("country") String country, @JsonProperty("timezone") String timezone,
             @JsonProperty("contractExpiryDate") String contractExpiryDate,
+            @JsonProperty("lastModifiedInstant") String lastModifiedInstant,
             @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.name = name;
         this.phone = phone;
@@ -54,6 +57,7 @@ class JsonAdaptedClient {
         this.country = country;
         this.timezone = timezone;
         this.contractExpiryDate = contractExpiryDate;
+        this.lastModifiedInstant = lastModifiedInstant;
         if (tagged != null) {
             this.tagged.addAll(tagged);
         }
@@ -70,6 +74,7 @@ class JsonAdaptedClient {
         country = source.getCountry().getCountryCode();
         timezone = source.getTimezone().toString();
         contractExpiryDate = source.getContractExpiryDate().value;
+        lastModifiedInstant = source.getLastModifiedInstant().toString();
         tagged.addAll(source.getTags().stream().map(JsonAdaptedTag::new).collect(Collectors.toList()));
     }
 
@@ -143,9 +148,16 @@ class JsonAdaptedClient {
         final ContractExpiryDate modelContractExpiryContractExpiryDate =
                 ParserUtil.parseContractExpiryDate(contractExpiryDate);
 
+        LastModifiedInstant modelLastModifiedInstant;
+        if (lastModifiedInstant == null) {
+            modelLastModifiedInstant = new LastModifiedInstant();
+        } else {
+            modelLastModifiedInstant = new LastModifiedInstant(lastModifiedInstant);
+        }
+
         final Set<Tag> modelTags = new HashSet<>(clientTags);
         return new Client(modelName, modelPhone, modelEmail, modelAddress, modelCountry,
-            modelTimezone, modelContractExpiryContractExpiryDate, modelTags);
+            modelTimezone, modelContractExpiryContractExpiryDate, modelLastModifiedInstant, modelTags);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -43,6 +43,8 @@ public class CommandTestUtil {
     public static final String VALID_TIMEZONE_BOB = "GMT+7";
     public static final String VALID_CONTRACT_EXPIRY_DATE_AMY = "1-1-2022";
     public static final String VALID_CONTRACT_EXPIRY_DATE_BOB = "13-12-2021";
+    public static final String VALID_LAST_MODIFIED_INSTANT_AMY = "2020-10-10T00:00:00.000000Z";
+    public static final String VALID_LAST_MODIFIED_INSTANT_BOB = "2020-11-11T00:00:00.000000Z";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 

--- a/src/test/java/seedu/address/model/client/ClientTest.java
+++ b/src/test/java/seedu/address/model/client/ClientTest.java
@@ -5,8 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_CONTRACT_EXPIRY_DATE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_COUNTRY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LAST_MODIFIED_INSTANT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
@@ -54,7 +56,7 @@ public class ClientTest {
 
         // same name, same phone, same email, different attributes -> returns true
         editedAlice = new ClientBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
-                .withCountry(VALID_COUNTRY_BOB).build();
+                .withCountry(VALID_COUNTRY_BOB).withLastModifiedInstant(VALID_LAST_MODIFIED_INSTANT_BOB).build();
         assertTrue(ALICE.isSameClient(editedAlice));
 
         // TODO: Add tests with modified notes
@@ -98,6 +100,14 @@ public class ClientTest {
         editedAlice = new ClientBuilder(ALICE).withCountry(VALID_COUNTRY_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
 
+        // different contract expiry date -> returns false
+        editedAlice = new ClientBuilder(ALICE).withContractExpiryDate(VALID_CONTRACT_EXPIRY_DATE_BOB).build();
+        assertFalse(ALICE.equals(editedAlice));
+
+        // different last modified instant -> returns true
+        editedAlice = new ClientBuilder(ALICE).withLastModifiedInstant(VALID_LAST_MODIFIED_INSTANT_BOB).build();
+        assertTrue(ALICE.equals(editedAlice));
+
         // different tags -> returns false
         editedAlice = new ClientBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
         assertFalse(ALICE.equals(editedAlice));
@@ -136,6 +146,14 @@ public class ClientTest {
         // different country -> hashCode is different
         editedAlice = new ClientBuilder(ALICE).withCountry(VALID_COUNTRY_BOB).build();
         assertNotEquals(ALICE.hashCode(), editedAlice.hashCode());
+
+        // different contract expiry date -> hashCode is different
+        editedAlice = new ClientBuilder(ALICE).withContractExpiryDate(VALID_CONTRACT_EXPIRY_DATE_BOB).build();
+        assertNotEquals(ALICE.hashCode(), editedAlice.hashCode());
+
+        // different last modified instant -> hashCode is same
+        editedAlice = new ClientBuilder(ALICE).withLastModifiedInstant(VALID_LAST_MODIFIED_INSTANT_BOB).build();
+        assertEquals(ALICE.hashCode(), editedAlice.hashCode());
 
         // different tags -> hashCode is different
         editedAlice = new ClientBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();

--- a/src/test/java/seedu/address/model/client/LastModifiedInstantTest.java
+++ b/src/test/java/seedu/address/model/client/LastModifiedInstantTest.java
@@ -98,7 +98,8 @@ class LastModifiedInstantTest {
         LastModifiedInstant lastModifiedInstant1 = new LastModifiedInstant(VALID_INSTANT_1);
         LastModifiedInstant lastModifiedInstant2 = new LastModifiedInstant(VALID_INSTANT_2);
         assertEquals(lastModifiedInstant1.hashCode(), lastModifiedInstant1.hashCode()); // same object
-        assertEquals(lastModifiedInstant1.hashCode(), new LastModifiedInstant(VALID_INSTANT_1).hashCode()); // same instant
+        assertEquals(lastModifiedInstant1.hashCode(),
+                new LastModifiedInstant(VALID_INSTANT_1).hashCode()); // same instant
         assertNotEquals(lastModifiedInstant1.hashCode(), lastModifiedInstant2.hashCode()); // different instant
     }
 

--- a/src/test/java/seedu/address/model/client/LastModifiedInstantTest.java
+++ b/src/test/java/seedu/address/model/client/LastModifiedInstantTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
+import java.time.Instant;
 import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,9 @@ class LastModifiedInstantTest {
     public void constructor_noArguments_returnsCurrentInstant() {
         LocalDate currentDate = LocalDate.now();
         LastModifiedInstant lastModifiedInstant = new LastModifiedInstant();
+        // Test to make sure the generated instant is within 1 second of now.
+        Instant instantNowMinusOneSecond = Instant.now().minusSeconds(1);
+        assertEquals(instantNowMinusOneSecond.compareTo(lastModifiedInstant.value), -1);
 
         LocalDate instantDate = LocalDate.parse(lastModifiedInstant.toString().substring(0, 10));
         assertEquals(currentDate.getYear(), instantDate.getYear());
@@ -61,7 +65,6 @@ class LastModifiedInstantTest {
         assertFalse(LastModifiedInstant.isValidInstant("2020-10-10T15:18.617617Z")); // missing seconds
         assertFalse(LastModifiedInstant.isValidInstant("2020-10-10T15:18:35.617617")); // missing Z
 
-
         // invalid parts
         assertFalse(LastModifiedInstant.isValidInstant("YYYY-10-10T15:18:35.617617Z")); // invalid year
         assertFalse(LastModifiedInstant.isValidInstant("2020-MM-10T15:18:35.617617Z")); // invalid month
@@ -73,7 +76,6 @@ class LastModifiedInstantTest {
         assertFalse(LastModifiedInstant.isValidInstant("2020-10-10T15:18:35.617617Y")); // invalid zone
         assertFalse(LastModifiedInstant.isValidInstant("2020-10-10Z15:18:35.617617Z")); // invalid separator
         assertFalse(LastModifiedInstant.isValidInstant("2020/10/10T15:18:35.617617Z")); // "/" instead of "-"
-
 
         // valid email
         assertTrue(LastModifiedInstant.isValidInstant("2020-10-10T15:18:35.617617Z")); // valid instant

--- a/src/test/java/seedu/address/model/client/LastModifiedInstantTest.java
+++ b/src/test/java/seedu/address/model/client/LastModifiedInstantTest.java
@@ -1,0 +1,121 @@
+package seedu.address.model.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+class LastModifiedInstantTest {
+
+    private static final String VALID_INSTANT_1 = "2020-10-10T15:18:35.617617Z";
+    private static final String VALID_INSTANT_2 = "2020-10-11T15:18:35.617617Z";
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new LastModifiedInstant(null));
+    }
+
+    @Test
+    public void constructor_invalidInstant_returnsCurrentInstant() {
+        LocalDate currentDate = LocalDate.now();
+        LastModifiedInstant lastModifiedInstant = new LastModifiedInstant("invalid instant");
+
+        LocalDate instantDate = LocalDate.parse(lastModifiedInstant.toString().substring(0, 10));
+        assertEquals(currentDate.getYear(), instantDate.getYear());
+        assertEquals(currentDate.getMonth(), instantDate.getMonth());
+        assertEquals(currentDate.getDayOfMonth(), instantDate.getDayOfMonth());
+    }
+
+    @Test
+    public void constructor_noArguments_returnsCurrentInstant() {
+        LocalDate currentDate = LocalDate.now();
+        LastModifiedInstant lastModifiedInstant = new LastModifiedInstant();
+
+        LocalDate instantDate = LocalDate.parse(lastModifiedInstant.toString().substring(0, 10));
+        assertEquals(currentDate.getYear(), instantDate.getYear());
+        assertEquals(currentDate.getMonth(), instantDate.getMonth());
+        assertEquals(currentDate.getDayOfMonth(), instantDate.getDayOfMonth());
+    }
+
+    @Test
+    public void isValidInstant() {
+        // null instant
+        assertThrows(NullPointerException.class, () -> LastModifiedInstant.isValidInstant(null));
+
+        // blank instant
+        assertFalse(LastModifiedInstant.isValidInstant("")); // empty string
+        assertFalse(LastModifiedInstant.isValidInstant(" ")); // spaces only
+
+        // missing parts
+        assertFalse(LastModifiedInstant.isValidInstant("-10-10T15:18:35.617617Z")); // missing year
+        assertFalse(LastModifiedInstant.isValidInstant("2020-10T15:18:35.617617Z")); // missing month
+        assertFalse(LastModifiedInstant.isValidInstant("2020-10T15:18:35.617617Z")); // missing day
+        assertFalse(LastModifiedInstant.isValidInstant("2020-10-1015:18:35.617617Z")); // missing T
+        assertFalse(LastModifiedInstant.isValidInstant("2020-10-10T18:35.617617Z")); // missing hour
+        assertFalse(LastModifiedInstant.isValidInstant("2020-10-10T15:35.617617Z")); // missing minutes
+        assertFalse(LastModifiedInstant.isValidInstant("2020-10-10T15:18.617617Z")); // missing seconds
+        assertFalse(LastModifiedInstant.isValidInstant("2020-10-10T15:18:35.617617")); // missing Z
+
+
+        // invalid parts
+        assertFalse(LastModifiedInstant.isValidInstant("YYYY-10-10T15:18:35.617617Z")); // invalid year
+        assertFalse(LastModifiedInstant.isValidInstant("2020-MM-10T15:18:35.617617Z")); // invalid month
+        assertFalse(LastModifiedInstant.isValidInstant("2020-10-DDT15:18:35.617617Z")); // invalid day
+        assertFalse(LastModifiedInstant.isValidInstant("2020-10-10THH:18:35.617617Z")); // invalid hour
+        assertFalse(LastModifiedInstant.isValidInstant("2020-10-10T15:MM:35.617617Z")); // invalid minute
+        assertFalse(LastModifiedInstant.isValidInstant("2020-10-10T15:18:SS.617617Z")); // invalid second
+        assertFalse(LastModifiedInstant.isValidInstant("2020-10-10T15:18:35.nanosecondZ")); // invalid nanoseconds
+        assertFalse(LastModifiedInstant.isValidInstant("2020-10-10T15:18:35.617617Y")); // invalid zone
+        assertFalse(LastModifiedInstant.isValidInstant("2020-10-10Z15:18:35.617617Z")); // invalid separator
+        assertFalse(LastModifiedInstant.isValidInstant("2020/10/10T15:18:35.617617Z")); // "/" instead of "-"
+
+
+        // valid email
+        assertTrue(LastModifiedInstant.isValidInstant("2020-10-10T15:18:35.617617Z")); // valid instant
+        assertTrue(LastModifiedInstant.isValidInstant("9999-12-31T23:59:59.999999Z")); // largest instant
+        assertTrue(LastModifiedInstant.isValidInstant("0000-01-01T00:00:00.000000Z")); // smallest instant
+        assertTrue(LastModifiedInstant.isValidInstant("2020-10-10T15:18:35.617Z")); // 3 digits for nano
+        assertTrue(LastModifiedInstant.isValidInstant("2020-10-10T15:18:35Z")); // no nano
+    }
+
+    @Test
+    public void equals() {
+        LastModifiedInstant lastModifiedInstant1 = new LastModifiedInstant(VALID_INSTANT_1);
+        LastModifiedInstant lastModifiedInstant2 = new LastModifiedInstant(VALID_INSTANT_2);
+
+        assertTrue(lastModifiedInstant1.equals(lastModifiedInstant1)); // same object
+        assertTrue(lastModifiedInstant1.equals(new LastModifiedInstant(VALID_INSTANT_1))); // same instant
+        assertFalse(lastModifiedInstant1.equals(lastModifiedInstant2)); // different instant
+    }
+
+    @Test
+    public void hashCode_test() {
+        LastModifiedInstant lastModifiedInstant1 = new LastModifiedInstant(VALID_INSTANT_1);
+        LastModifiedInstant lastModifiedInstant2 = new LastModifiedInstant(VALID_INSTANT_2);
+        assertEquals(lastModifiedInstant1.hashCode(), lastModifiedInstant1.hashCode()); // same object
+        assertEquals(lastModifiedInstant1.hashCode(), new LastModifiedInstant(VALID_INSTANT_1).hashCode()); // same instant
+        assertNotEquals(lastModifiedInstant1.hashCode(), lastModifiedInstant2.hashCode()); // different instant
+    }
+
+    @Test
+    public void compareTo() {
+        LastModifiedInstant lastModifiedInstant1 = new LastModifiedInstant(VALID_INSTANT_1);
+        LastModifiedInstant lastModifiedInstant2 = new LastModifiedInstant(VALID_INSTANT_2);
+
+        assertEquals(lastModifiedInstant1.compareTo(lastModifiedInstant2), -1);
+        assertEquals(lastModifiedInstant2.compareTo(lastModifiedInstant1), 1);
+        assertEquals(lastModifiedInstant1.compareTo(lastModifiedInstant1), 0);
+        assertEquals(lastModifiedInstant1.compareTo(new LastModifiedInstant(VALID_INSTANT_1)), 0);
+    }
+
+    @Test
+    public void toString_test() {
+        LastModifiedInstant lastModifiedInstant1 = new LastModifiedInstant(VALID_INSTANT_1);
+        assertEquals(VALID_INSTANT_1, lastModifiedInstant1.toString());
+    }
+}

--- a/src/test/java/seedu/address/storage/JsonAdaptedClientTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedClientTest.java
@@ -1,5 +1,6 @@
 package seedu.address.storage;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.storage.JsonAdaptedClient.MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -29,6 +30,7 @@ public class JsonAdaptedClientTest {
     private static final String INVALID_COUNTRY = "ZZ";
     private static final String INVALID_TIMEZONE = "GT+8";
     private static final String INVALID_CONTRACT_EXPIRY_DATE = "1,2,2020";
+    private static final String INVALID_LAST_MODIFIED_INSTANT = "2020/20/20T12:12:12Z";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = BENSON.getName().toString();
@@ -38,6 +40,7 @@ public class JsonAdaptedClientTest {
     private static final String VALID_COUNTRY = BENSON.getCountry().getCountryCode();
     private static final String VALID_TIMEZONE = BENSON.getTimezone().toString();
     private static final String VALID_CONTRACT_EXPIRY_DATE = BENSON.getContractExpiryDate().toString();
+    private static final String VALID_LAST_MODIFIED_INSTANT = BENSON.getLastModifiedInstant().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -51,7 +54,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_LAST_MODIFIED_INSTANT, VALID_TAGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -59,7 +62,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_LAST_MODIFIED_INSTANT, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -67,7 +70,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_LAST_MODIFIED_INSTANT, VALID_TAGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -75,7 +78,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_LAST_MODIFIED_INSTANT, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -83,7 +86,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_LAST_MODIFIED_INSTANT, VALID_TAGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -91,7 +94,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_LAST_MODIFIED_INSTANT, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -99,7 +102,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_LAST_MODIFIED_INSTANT, VALID_TAGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -107,7 +110,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_LAST_MODIFIED_INSTANT, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -115,7 +118,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_invalidCountry_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                INVALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
+                INVALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_LAST_MODIFIED_INSTANT, VALID_TAGS);
         String expectedMessage = CountryCodeVerifier.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -123,7 +126,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_nullCountry_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                null, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
+                null, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_LAST_MODIFIED_INSTANT, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Country.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -131,7 +134,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_invalidTimezone_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_COUNTRY, INVALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
+                VALID_COUNTRY, INVALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_LAST_MODIFIED_INSTANT, VALID_TAGS);
         String expectedMessage = Timezone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -139,7 +142,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_nullTimezone_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_COUNTRY, null, VALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
+                VALID_COUNTRY, null, VALID_CONTRACT_EXPIRY_DATE, VALID_LAST_MODIFIED_INSTANT, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Timezone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -147,7 +150,7 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_invalidContractExpiryDate_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, INVALID_CONTRACT_EXPIRY_DATE, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, INVALID_CONTRACT_EXPIRY_DATE, VALID_LAST_MODIFIED_INSTANT, VALID_TAGS);
         String expectedMessage = ContractExpiryDate.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
     }
@@ -155,9 +158,23 @@ public class JsonAdaptedClientTest {
     @Test
     public void toModelType_nullContractExpiryDate_throwsIllegalValueException() {
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, null, VALID_TAGS);
+                VALID_COUNTRY, VALID_TIMEZONE, null, VALID_LAST_MODIFIED_INSTANT, VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, ContractExpiryDate.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, client::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidLastModifiedInstant_doesNotThrowException() {
+        JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, INVALID_LAST_MODIFIED_INSTANT, VALID_TAGS);
+        assertDoesNotThrow(client::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullLastModifiedInstant_doesNotThrowException() {
+        JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, null, VALID_TAGS);
+        assertDoesNotThrow(client::toModelType);
     }
 
     @Test
@@ -165,7 +182,7 @@ public class JsonAdaptedClientTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedClient client = new JsonAdaptedClient(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, invalidTags);
+                VALID_COUNTRY, VALID_TIMEZONE, VALID_CONTRACT_EXPIRY_DATE, VALID_LAST_MODIFIED_INSTANT, invalidTags);
         assertThrows(IllegalValueException.class, client::toModelType);
     }
 

--- a/src/test/java/seedu/address/testutil/ClientBuilder.java
+++ b/src/test/java/seedu/address/testutil/ClientBuilder.java
@@ -148,6 +148,10 @@ public class ClientBuilder {
         return this;
     }
 
+    /**
+     * Builds a client with the specified fields in {@code ClientBuilder}.
+     * @return Client with fields in {@code ClientBuilder}.
+     */
     public Client build() {
         return new Client(name, phone, email, address, country, timezone, contractExpiryDate,
                 lastModifiedInstant, tags);

--- a/src/test/java/seedu/address/testutil/ClientBuilder.java
+++ b/src/test/java/seedu/address/testutil/ClientBuilder.java
@@ -7,6 +7,7 @@ import seedu.address.model.client.Address;
 import seedu.address.model.client.Client;
 import seedu.address.model.client.ContractExpiryDate;
 import seedu.address.model.client.Email;
+import seedu.address.model.client.LastModifiedInstant;
 import seedu.address.model.client.Name;
 import seedu.address.model.client.Phone;
 import seedu.address.model.client.Timezone;
@@ -34,6 +35,7 @@ public class ClientBuilder {
     private Country country;
     private Timezone timezone;
     private ContractExpiryDate contractExpiryDate;
+    private LastModifiedInstant lastModifiedInstant;
     private Set<Tag> tags;
 
     /**
@@ -47,6 +49,7 @@ public class ClientBuilder {
         country = new Country(DEFAULT_COUNTRY);
         timezone = new Timezone(DEFAULT_TIMEZONE);
         contractExpiryDate = new ContractExpiryDate(DEFAULT_CONTRACT_EXPIRY_DATE);
+        lastModifiedInstant = new LastModifiedInstant();
         tags = new HashSet<>();
     }
 
@@ -61,6 +64,7 @@ public class ClientBuilder {
         country = clientToCopy.getCountry();
         timezone = clientToCopy.getTimezone();
         contractExpiryDate = clientToCopy.getContractExpiryDate();
+        lastModifiedInstant = clientToCopy.getLastModifiedInstant();
         tags = new HashSet<>(clientToCopy.getTags());
     }
 
@@ -136,8 +140,17 @@ public class ClientBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code LastModifiedInstant} of the {@code Client} that we are building.
+     */
+    public ClientBuilder withLastModifiedInstant(String lastModifiedInstant) {
+        this.lastModifiedInstant = new LastModifiedInstant(lastModifiedInstant);
+        return this;
+    }
+
     public Client build() {
-        return new Client(name, phone, email, address, country, timezone, contractExpiryDate, tags);
+        return new Client(name, phone, email, address, country, timezone, contractExpiryDate,
+                lastModifiedInstant, tags);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalClients.java
+++ b/src/test/java/seedu/address/testutil/TypicalClients.java
@@ -32,34 +32,37 @@ public class TypicalClients {
     public static final Client ALICE = new ClientBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253").withCountry("SG").withTimezone("GMT+8").withContractExpiryDate("1-4-2021")
-            .withTags("friends").build();
+            .withLastModifiedInstant("2020-01-01T00:00:00.000000Z").withTags("friends").build();
     public static final Client BENSON = new ClientBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25").withCountry("SG").withTimezone("GMT+8")
             .withEmail("johnd@example.com").withPhone("98765432").withContractExpiryDate("3-12-2022")
-            .withTags("owesMoney", "friends").build();
+            .withLastModifiedInstant("2020-02-02T00:00:00.000000Z").withTags("owesMoney", "friends").build();
     public static final Client CARL = new ClientBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").withCountry("US").withTimezone("GMT-4")
-            .withContractExpiryDate("30-1-2022").build();
+            .withContractExpiryDate("30-1-2022").withLastModifiedInstant("2020-03-03T00:00:00.000000Z").build();
     public static final Client DANIEL = new ClientBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withAddress("10th street").withCountry("SG")
-            .withTimezone("GMT+8").withContractExpiryDate("28-2-2021").withTags("friends").build();
+            .withTimezone("GMT+8").withContractExpiryDate("28-2-2021")
+            .withLastModifiedInstant("2020-04-04T00:00:00.000000Z").withTags("friends").build();
     public static final Client ELLE = new ClientBuilder().withName("Elle Meyer").withPhone("9482224")
             .withEmail("werner@example.com").withAddress("michegan ave").withCountry("GB")
-            .withTimezone("GMT+1").withContractExpiryDate("10-10-2024").build();
+            .withTimezone("GMT+1").withContractExpiryDate("10-10-2024")
+            .withLastModifiedInstant("2020-05-05T00:00:00.000000Z").build();
     public static final Client FIONA = new ClientBuilder().withName("Fiona Kunz").withPhone("9482427")
             .withEmail("lydia@example.com").withAddress("little tokyo").withCountry("JP").withTimezone("GMT+9")
-            .withContractExpiryDate("9-11-2022").build();
+            .withContractExpiryDate("9-11-2022").withLastModifiedInstant("2020-06-06T00:00:00.000000Z").build();
     public static final Client GEORGE = new ClientBuilder().withName("George Best").withPhone("9482442")
             .withEmail("anna@example.com").withAddress("4th street").withCountry("US").withTimezone("GMT-4")
-            .withContractExpiryDate("2-8-2021").build();
+            .withContractExpiryDate("2-8-2021").withLastModifiedInstant("2020-07-07T00:00:00.000000Z").build();
 
     // Manually added
     public static final Client HOON = new ClientBuilder().withName("Hoon Meier").withPhone("8482424")
             .withEmail("stefan@example.com").withAddress("little india").withCountry("IN")
-            .withTimezone("GMT+5").withContractExpiryDate("23-4-2021").build();
+            .withTimezone("GMT+5").withContractExpiryDate("23-4-2021")
+            .withLastModifiedInstant("2020-08-08T00:00:00.000000Z").build();
     public static final Client IDA = new ClientBuilder().withName("Ida Mueller").withPhone("8482131")
             .withEmail("hans@example.com").withAddress("chicago ave").withCountry("US").withTimezone("GMT-4")
-            .withContractExpiryDate("31-12-2020").build();
+            .withContractExpiryDate("31-12-2020").withLastModifiedInstant("2020-09-09T00:00:00.000000Z").build();
 
     // Manually added - Client's details found in {@code CommandTestUtil}
     public static final Client AMY = new ClientBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)


### PR DESCRIPTION
## Description

Added new field `LastModifiedInstant` to `Client`. This field is updated every time `Client` is created or edited for now. Adding or deleting notes currently does not update this field.

Fixes #218 

## Testing

Unit tests are done for the field and all its methods.
`LastModifiedInstant` field does not affect equality / hashcode of `Client` since the creation of a new `Client` to check modifies this `LastModifiedInstant` field.

