### PR TITLE
Country note delete

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,7 +8,8 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX = "The client index provided is invalid";
-    public static final String MESSAGE_INVALID_COUNTRY_NOTE_DISPLAYED_INDEX = "The country note index provided is invalid";
+    public static final String MESSAGE_INVALID_COUNTRY_NOTE_DISPLAYED_INDEX =
+            "The country note index provided is invalid";
     public static final String MESSAGE_CLIENTS_LISTED_OVERVIEW = "%1$d clients listed!";
 
 }

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX = "The client index provided is invalid";
+    public static final String MESSAGE_INVALID_COUNTRY_NOTE_DISPLAYED_INDEX = "The country note index provided is invalid";
     public static final String MESSAGE_CLIENTS_LISTED_OVERVIEW = "%1$d clients listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/ClientViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientViewCommand.java
@@ -52,7 +52,7 @@ public class ClientViewCommand extends Command {
         Client clientToView = lastShownList.get(targetIndex.getZeroBased());
         model.setWidgetContent(clientToView);
         return new CommandResult(String.format(MESSAGE_VIEW_CLIENT_SUCCESS, clientToView.getName()),
-                false, false, WidgetViewOption.CLIENT);
+                false, false, WidgetViewOption.generateClientWidgetOption());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -24,9 +24,6 @@ public class CommandResult {
     /** Indicates what kind of display to show on the widget view box. */
     private final WidgetViewOption widgetViewOption;
 
-    /** The country to display. */
-    private final Country country;
-
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
@@ -36,7 +33,6 @@ public class CommandResult {
         this.showHelp = showHelp;
         this.exit = exit;
         this.widgetViewOption = WidgetViewOption.generateNullWidgetOption();
-        this.country = null;
     }
 
     /**
@@ -48,7 +44,6 @@ public class CommandResult {
         this.showHelp = showHelp;
         this.exit = exit;
         this.widgetViewOption = widgetViewOption;
-        this.country = null;
     }
 
     /**
@@ -71,18 +66,38 @@ public class CommandResult {
         return exit;
     }
 
-    public WidgetViewOption getWidgetViewOption() {
-        return widgetViewOption;
+    /**
+     * Returns the string representation of the widget view.
+     *
+     * @return The string representation of the widget view.
+     */
+    public String getWidgetViewOptionAsString() {
+        return widgetViewOption.toString();
     }
 
+    /**
+     * Returns true if the UI should display the client view.
+     *
+     * @return True if the UI should display the client view.
+     */
     public boolean shouldDisplayClient() {
         return widgetViewOption.isClient();
     }
 
+    /**
+     * Returns true if the UI should display the country notes view.
+     *
+     * @return True if the UI should display the country notes view.
+     */
     public boolean shouldDisplayCountryNote() {
         return widgetViewOption.isCountryNote();
     }
 
+    /**
+     * Gets the country that is associated with the widget view.
+     *
+     * @return The country that is associated with the widget view.
+     */
     public Country getCountry() {
         return widgetViewOption.getCountry();
     }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Objects;
 
+import seedu.address.model.country.Country;
 import seedu.address.ui.WidgetViewOption;
 
 /**
@@ -23,6 +24,9 @@ public class CommandResult {
     /** Indicates what kind of display to show on the widget view box. */
     private final WidgetViewOption widgetViewOption;
 
+    /** The country to display. */
+    private final Country country;
+
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
@@ -31,7 +35,8 @@ public class CommandResult {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
-        this.widgetViewOption = WidgetViewOption.NONE;
+        this.widgetViewOption = WidgetViewOption.generateNullWidgetOption();
+        this.country = null;
     }
 
     /**
@@ -43,6 +48,7 @@ public class CommandResult {
         this.showHelp = showHelp;
         this.exit = exit;
         this.widgetViewOption = widgetViewOption;
+        this.country = null;
     }
 
     /**
@@ -67,6 +73,18 @@ public class CommandResult {
 
     public WidgetViewOption getWidgetViewOption() {
         return widgetViewOption;
+    }
+
+    public boolean shouldDisplayClient() {
+        return widgetViewOption.isClient();
+    }
+
+    public boolean shouldDisplayCountryNote() {
+        return widgetViewOption.isCountryNote();
+    }
+
+    public Country getCountry() {
+        return widgetViewOption.getCountry();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CountryNoteDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteDeleteCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Objects;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -47,5 +48,28 @@ public class CountryNoteDeleteCommand extends Command {
         return new CommandResult(
                 String.format(MESSAGE_SUCCESS, targetIndex.getOneBased(), countryNoteToDelete), false, false,
                 WidgetViewOption.generateNullWidgetOption());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof CountryNoteDeleteCommand)) {
+            return false;
+        }
+
+        // state check
+        CountryNoteDeleteCommand c = (CountryNoteDeleteCommand) other;
+
+        return targetIndex.equals(c.targetIndex);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(targetIndex);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/CountryNoteDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteDeleteCommand.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 
 import java.util.List;
 
@@ -12,17 +11,24 @@ import seedu.address.model.Model;
 import seedu.address.model.note.CountryNote;
 import seedu.address.ui.WidgetViewOption;
 
+/**
+ * A class that encapsulates the logic for deleting country notes.
+ */
 public class CountryNoteDeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "country ndelete"; // TODO: change to country note delete
     public static final String MESSAGE_USAGE = COMMAND_WORD
         + ": Deletes the country note that are associated with the last viewed country at the given index.\n"
-        + "Parameters: "
-        + PREFIX_INDEX + "INDEX"
-        + "Example: " + COMMAND_WORD + " " + PREFIX_INDEX + "1";
+        + "Parameters: INDEX"
+        + "Example: " + COMMAND_WORD + " 1";
     private static final String MESSAGE_SUCCESS = "Deleted country note at index %1$s: %2$s";
     private final Index targetIndex;
 
+    /**
+     * Initializes a CountryNoteDeleteCommand with the given targetIndex.
+     *
+     * @param targetIndex The given targetIndex.
+     */
     public CountryNoteDeleteCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }
@@ -33,12 +39,12 @@ public class CountryNoteDeleteCommand extends Command {
         List<CountryNote> lastShownList = model.getFilteredCountryNoteList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MESSAGE_INVALID_COUNTRY_NOTE_DISPLAYED_INDEX);
         }
 
         CountryNote countryNoteToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteCountryNote(countryNoteToDelete);
         return new CommandResult(String.format(MESSAGE_SUCCESS, targetIndex.getOneBased(), countryNoteToDelete), false, false,
-            WidgetViewOption.generateCountryNoteWidgetOption(null));
+            WidgetViewOption.generateNullWidgetOption());
     }
 }

--- a/src/main/java/seedu/address/logic/commands/CountryNoteDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteDeleteCommand.java
@@ -20,7 +20,7 @@ public class CountryNoteDeleteCommand extends Command {
     public static final String COMMAND_WORD = "country ndelete"; // TODO: change to country note delete
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the country note that are associated with the last viewed country at the given index.\n"
-            + "Parameters: INDEX"
+            + "Parameters: INDEX\n"
             + "Example: " + COMMAND_WORD + " 1";
     private static final String MESSAGE_SUCCESS = "Deleted country note at index %1$s: %2$s";
     private final Index targetIndex;

--- a/src/main/java/seedu/address/logic/commands/CountryNoteDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteDeleteCommand.java
@@ -1,0 +1,44 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.note.CountryNote;
+import seedu.address.ui.WidgetViewOption;
+
+public class CountryNoteDeleteCommand extends Command {
+
+    public static final String COMMAND_WORD = "country ndelete"; // TODO: change to country note delete
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+        + ": Deletes the country note that are associated with the last viewed country at the given index.\n"
+        + "Parameters: "
+        + PREFIX_INDEX + "INDEX"
+        + "Example: " + COMMAND_WORD + " " + PREFIX_INDEX + "1";
+    private static final String MESSAGE_SUCCESS = "Deleted country note at index %1$s: %2$s";
+    private final Index targetIndex;
+
+    public CountryNoteDeleteCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<CountryNote> lastShownList = model.getFilteredCountryNoteList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
+        }
+
+        CountryNote countryNoteToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteCountryNote(countryNoteToDelete);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, targetIndex.getOneBased(), countryNoteToDelete), false, false,
+            WidgetViewOption.generateCountryNoteWidgetOption(null));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/CountryNoteDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteDeleteCommand.java
@@ -18,9 +18,9 @@ public class CountryNoteDeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "country ndelete"; // TODO: change to country note delete
     public static final String MESSAGE_USAGE = COMMAND_WORD
-        + ": Deletes the country note that are associated with the last viewed country at the given index.\n"
-        + "Parameters: INDEX"
-        + "Example: " + COMMAND_WORD + " 1";
+            + ": Deletes the country note that are associated with the last viewed country at the given index.\n"
+            + "Parameters: INDEX"
+            + "Example: " + COMMAND_WORD + " 1";
     private static final String MESSAGE_SUCCESS = "Deleted country note at index %1$s: %2$s";
     private final Index targetIndex;
 
@@ -44,7 +44,8 @@ public class CountryNoteDeleteCommand extends Command {
 
         CountryNote countryNoteToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteCountryNote(countryNoteToDelete);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, targetIndex.getOneBased(), countryNoteToDelete), false, false,
-            WidgetViewOption.generateNullWidgetOption());
+        return new CommandResult(
+                String.format(MESSAGE_SUCCESS, targetIndex.getOneBased(), countryNoteToDelete), false, false,
+                WidgetViewOption.generateNullWidgetOption());
     }
 }

--- a/src/main/java/seedu/address/logic/commands/CountryNoteViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteViewCommand.java
@@ -37,7 +37,7 @@ public class CountryNoteViewCommand extends Command {
      * Initializes a CountryNoteViewCommand that views all country notes.
      */
     public CountryNoteViewCommand() {
-        this.country = null;
+        this.country = Country.getNullCountry();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CountryNoteViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteViewCommand.java
@@ -37,19 +37,19 @@ public class CountryNoteViewCommand extends Command {
      * Initializes a CountryNoteViewCommand that views all country notes.
      */
     public CountryNoteViewCommand() {
-        this.country = Country.getNullCountry();
+        this.country = Country.NULL_COUNTRY;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        if (country.equals(Country.getNullCountry())) {
+        if (country.equals(Country.NULL_COUNTRY)) {
             model.updateFilteredCountryNoteList(countryNote -> true);
         } else {
             model.updateFilteredCountryNoteList(countryNote -> countryNote.getCountry().equals(country));
         }
         return new CommandResult(String.format(MESSAGE_SUCCESS,
-                country.equals(Country.getNullCountry()) ? "all countries" : country),
+                country.equals(Country.NULL_COUNTRY) ? "all countries" : country),
             false, false, WidgetViewOption.generateCountryNoteWidgetOption(country));
     }
 

--- a/src/main/java/seedu/address/logic/commands/CountryNoteViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteViewCommand.java
@@ -43,12 +43,13 @@ public class CountryNoteViewCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        if (country == null) {
+        if (country.equals(Country.getNullCountry())) {
             model.updateFilteredCountryNoteList(countryNote -> true);
         } else {
             model.updateFilteredCountryNoteList(countryNote -> countryNote.getCountry().equals(country));
         }
-        return new CommandResult(String.format(MESSAGE_SUCCESS, country == null ? "all countries" : country),
+        return new CommandResult(String.format(MESSAGE_SUCCESS,
+                country.equals(Country.getNullCountry()) ? "all countries" : country),
             false, false, WidgetViewOption.generateCountryNoteWidgetOption(country));
     }
 

--- a/src/main/java/seedu/address/logic/commands/CountryNoteViewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteViewCommand.java
@@ -33,11 +33,23 @@ public class CountryNoteViewCommand extends Command {
         this.country = country;
     }
 
+    /**
+     * Initializes a CountryNoteViewCommand that views all country notes.
+     */
+    public CountryNoteViewCommand() {
+        this.country = null;
+    }
+
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredCountryNoteList(countryNote -> countryNote.getCountry().equals(country));
-        return new CommandResult(String.format(MESSAGE_SUCCESS, country), false, false, WidgetViewOption.COUNTRY_NOTES);
+        if (country == null) {
+            model.updateFilteredCountryNoteList(countryNote -> true);
+        } else {
+            model.updateFilteredCountryNoteList(countryNote -> countryNote.getCountry().equals(country));
+        }
+        return new CommandResult(String.format(MESSAGE_SUCCESS, country == null ? "all countries" : country),
+            false, false, WidgetViewOption.generateCountryNoteWidgetOption(country));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.ClientViewCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CountryFilterCommand;
 import seedu.address.logic.commands.CountryNoteCommand;
+import seedu.address.logic.commands.CountryNoteDeleteCommand;
 import seedu.address.logic.commands.CountryNoteViewCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -121,6 +122,8 @@ public class AddressBookParser {
 
         case CountryNoteViewCommand.COMMAND_WORD:
             return new CountryNoteViewCommandParser().parse(restOfCommand);
+        case CountryNoteDeleteCommand.COMMAND_WORD:
+            return new CountryNoteDeleteCommandParser().parse(restOfCommand);
 
         case CountryFilterCommand.COMMAND_WORD:
             return new CountryFilterCommandParser().parse(restOfCommand);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -122,6 +122,7 @@ public class AddressBookParser {
 
         case CountryNoteViewCommand.COMMAND_WORD:
             return new CountryNoteViewCommandParser().parse(restOfCommand);
+
         case CountryNoteDeleteCommand.COMMAND_WORD:
             return new CountryNoteDeleteCommandParser().parse(restOfCommand);
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,7 +15,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_TIMEZONE = new Prefix("tz/");
     public static final Prefix PREFIX_CONTRACT_EXPIRY_DATE = new Prefix("ce/");
     public static final Prefix PREFIX_NOTE = new Prefix("nt/");
-    public static final Prefix PREFIX_INDEX = new Prefix("idx/");
     public static final Prefix PREFIX_SUGGEST = new Prefix("by/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,6 +15,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_TIMEZONE = new Prefix("tz/");
     public static final Prefix PREFIX_CONTRACT_EXPIRY_DATE = new Prefix("ce/");
     public static final Prefix PREFIX_NOTE = new Prefix("nt/");
+    public static final Prefix PREFIX_INDEX = new Prefix("idx/");
     public static final Prefix PREFIX_SUGGEST = new Prefix("by/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/CountryFilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CountryFilterCommandParser.java
@@ -25,7 +25,7 @@ public class CountryFilterCommandParser implements Parser<CountryFilterCommand> 
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_COUNTRY);
 
-        if (argMultimap.getValue(PREFIX_COUNTRY).isEmpty()) {
+        if (argMultimap.getValue(PREFIX_COUNTRY).isEmpty() || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, CountryFilterCommand.MESSAGE_USAGE));
         }
         String countryCode = argMultimap.getValue(PREFIX_COUNTRY).get();

--- a/src/main/java/seedu/address/logic/parser/CountryNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CountryNoteCommandParser.java
@@ -28,7 +28,7 @@ public class CountryNoteCommandParser implements Parser<CountryNoteCommand> {
                 ArgumentTokenizer.tokenize(args, PREFIX_COUNTRY, PREFIX_NOTE);
 
         if (argMultimap.getValue(PREFIX_COUNTRY).isEmpty() || argMultimap.getValue(PREFIX_NOTE).isEmpty()
-            || !argMultimap.getPreamble().isEmpty()) {
+                || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, CountryNoteCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/CountryNoteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CountryNoteCommandParser.java
@@ -27,7 +27,8 @@ public class CountryNoteCommandParser implements Parser<CountryNoteCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_COUNTRY, PREFIX_NOTE);
 
-        if (argMultimap.getValue(PREFIX_COUNTRY).isEmpty() || argMultimap.getValue(PREFIX_NOTE).isEmpty()) {
+        if (argMultimap.getValue(PREFIX_COUNTRY).isEmpty() || argMultimap.getValue(PREFIX_NOTE).isEmpty()
+            || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, CountryNoteCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/logic/parser/CountryNoteDeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CountryNoteDeleteCommandParser.java
@@ -1,0 +1,21 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CountryNoteDeleteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class CountryNoteDeleteCommandParser implements Parser<CountryNoteDeleteCommand> {
+
+    @Override
+    public CountryNoteDeleteCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new CountryNoteDeleteCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CountryNoteDeleteCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/CountryNoteDeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CountryNoteDeleteCommandParser.java
@@ -6,6 +6,9 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.CountryNoteDeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
+/**
+ * A class that parses the user input and returns a CountryNoteDeleteCommand.
+ */
 public class CountryNoteDeleteCommandParser implements Parser<CountryNoteDeleteCommand> {
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/CountryNoteViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CountryNoteViewCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNTRY;
 
 import seedu.address.logic.commands.CountryNoteViewCommand;
@@ -15,6 +16,11 @@ public class CountryNoteViewCommandParser implements Parser<CountryNoteViewComma
     public CountryNoteViewCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_COUNTRY);
+
+        if (!argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, CountryNoteViewCommand.MESSAGE_USAGE));
+        }
 
         if (argMultimap.getValue(PREFIX_COUNTRY).isEmpty()) {
             return new CountryNoteViewCommand();

--- a/src/main/java/seedu/address/logic/parser/CountryNoteViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CountryNoteViewCommandParser.java
@@ -19,8 +19,6 @@ public class CountryNoteViewCommandParser implements Parser<CountryNoteViewComma
 
         if (argMultimap.getValue(PREFIX_COUNTRY).isEmpty()) {
             return new CountryNoteViewCommand();
-            //throw new ParseException(
-            //    String.format(MESSAGE_INVALID_COMMAND_FORMAT, CountryNoteViewCommand.MESSAGE_USAGE));
         }
         Country country = ParserUtil.parseCountry(argMultimap.getValue(PREFIX_COUNTRY).get());
 

--- a/src/main/java/seedu/address/logic/parser/CountryNoteViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CountryNoteViewCommandParser.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_COUNTRY;
 
 import seedu.address.logic.commands.CountryNoteViewCommand;

--- a/src/main/java/seedu/address/logic/parser/CountryNoteViewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CountryNoteViewCommandParser.java
@@ -18,8 +18,9 @@ public class CountryNoteViewCommandParser implements Parser<CountryNoteViewComma
                 ArgumentTokenizer.tokenize(args, PREFIX_COUNTRY);
 
         if (argMultimap.getValue(PREFIX_COUNTRY).isEmpty()) {
-            throw new ParseException(
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CountryNoteViewCommand.MESSAGE_USAGE));
+            return new CountryNoteViewCommand();
+            //throw new ParseException(
+            //    String.format(MESSAGE_INVALID_COMMAND_FORMAT, CountryNoteViewCommand.MESSAGE_USAGE));
         }
         Country country = ParserUtil.parseCountry(argMultimap.getValue(PREFIX_COUNTRY).get());
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -188,6 +188,11 @@ public class AddressBook implements ReadOnlyAddressBook {
         return FXCollections.observableArrayList(countryNotesManager.asUnmodifiableObservableList());
     }
 
+    /**
+     * Gets the list of country notes in TBM.
+     *
+     * @return The list of country notes in TBM.
+     */
     public ObservableList<CountryNote> getCountryNoteList() {
         return countryNotesManager.asUnmodifiableObservableList();
     }
@@ -203,6 +208,4 @@ public class AddressBook implements ReadOnlyAddressBook {
     public int hashCode() {
         return clients.hashCode();
     }
-
-
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -159,6 +159,16 @@ public class AddressBook implements ReadOnlyAddressBook {
         countryNotesManager.addCountryNote(countryNote);
     }
 
+    /**
+     * Deletes the given country note.
+     *
+     * @param countryNoteToDelete The country note to delete.
+     */
+    public void deleteCountryNote(CountryNote countryNoteToDelete) {
+        requireNonNull(countryNoteToDelete);
+        countryNotesManager.deleteCountryNote(countryNoteToDelete);
+    }
+
     //// util methods
 
     @Override
@@ -193,4 +203,6 @@ public class AddressBook implements ReadOnlyAddressBook {
     public int hashCode() {
         return clients.hashCode();
     }
+
+
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -191,7 +191,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     /**
      * Gets the list of country notes in TBM as an unmodifiable observable list.
      *
-     * @return The list of country notes in TBM.
+     * @return The unmodifiable observable list of country notes in TBM.
      */
     public ObservableList<CountryNote> getCountryNoteList() {
         return countryNotesManager.asUnmodifiableObservableList();

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -189,7 +189,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
-     * Gets the list of country notes in TBM.
+     * Gets the list of country notes in TBM as an unmodifiable observable list.
      *
      * @return The list of country notes in TBM.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -179,6 +179,4 @@ public interface Model {
      * @param note    The note to associate the tag with.
      */
     void updateTagNoteMapWithNote(Set<Tag> newTags, Note note);
-
-
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -111,6 +111,11 @@ public interface Model {
     void addCountryNote(CountryNote countryNote);
 
     /**
+     * Deletes the given country note in TBM.
+     */
+    void deleteCountryNote(CountryNote countryNoteToDelete);
+
+    /**
      * Returns true if {@code client} contains the {@code clientNote} specified.
      */
     boolean hasClientNote(Client client, Note clientNote);
@@ -174,4 +179,6 @@ public interface Model {
      * @param note    The note to associate the tag with.
      */
     void updateTagNoteMapWithNote(Set<Tag> newTags, Note note);
+
+
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -163,6 +163,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void deleteCountryNote(CountryNote countryNoteToDelete) {
+        requireNonNull(countryNoteToDelete);
+        addressBook.deleteCountryNote(countryNoteToDelete);
+    }
+
+    @Override
     public void addClientNote(Client target, Note clientNote) {
         requireAllNonNull(target, clientNote);
         target.addClientNote(clientNote);

--- a/src/main/java/seedu/address/model/country/Country.java
+++ b/src/main/java/seedu/address/model/country/Country.java
@@ -8,6 +8,7 @@ import java.util.Locale;
  */
 public class Country {
 
+    public static final Country NULL_COUNTRY = new Country();
     private static final String NONE_COUNTRY_CODE = "";
     private static final String NONE_COUNTRY_NAME = "";
 
@@ -29,10 +30,6 @@ public class Country {
     private Country() {
         this.countryCode = NONE_COUNTRY_CODE;
         this.countryName = NONE_COUNTRY_NAME;
-    }
-
-    public static Country getNullCountry() {
-        return new Country();
     }
 
     /**

--- a/src/main/java/seedu/address/model/country/Country.java
+++ b/src/main/java/seedu/address/model/country/Country.java
@@ -8,6 +8,9 @@ import java.util.Locale;
  */
 public class Country {
 
+    private static final String NONE_COUNTRY_CODE = "";
+    private static final String NONE_COUNTRY_NAME = "";
+
     private final String countryName;
     private final String countryCode;
 
@@ -21,6 +24,15 @@ public class Country {
 
         this.countryCode = countryCode;
         this.countryName = new Locale("", countryCode).getDisplayName();
+    }
+
+    private Country() {
+        this.countryCode = NONE_COUNTRY_CODE;
+        this.countryName = NONE_COUNTRY_NAME;
+    }
+
+    public static Country getNullCountry() {
+        return new Country();
     }
 
     /**

--- a/src/main/java/seedu/address/model/country/CountryNotesManager.java
+++ b/src/main/java/seedu/address/model/country/CountryNotesManager.java
@@ -43,12 +43,29 @@ public class CountryNotesManager {
     }
 
     /**
-     * Returns all Country Notes. Returning a list of all country notes prevents deep-copying.
+     * Returns all Country Notes as an unmodifiable List.
      *
-     * @return List of all country notes.
+     * @return Unmodifiable list of all country notes.
      */
     public ObservableList<CountryNote> asUnmodifiableObservableList() {
         return internalCountryNoteUnmodifiableList;
     }
 
+    /**
+     * Deletes the given country note.
+     *
+     * @param countryNoteToDelete The country note to be deleted.
+     */
+    public void deleteCountryNote(CountryNote countryNoteToDelete) {
+        if (!CountryCodeVerifier.isValidCountryCode(countryNoteToDelete.getCountry().getCountryCode())) {
+            assert false; // should always be a valid country
+        }
+        requireNonNull(countryNoteToDelete);
+
+        //TODO: throw exception if country note not exist
+        if (hasCountryNote(countryNoteToDelete)) {
+            internalCountryNoteList.remove(countryNoteToDelete);
+        }
+
+    }
 }

--- a/src/main/java/seedu/address/model/country/CountryNotesManager.java
+++ b/src/main/java/seedu/address/model/country/CountryNotesManager.java
@@ -61,11 +61,8 @@ public class CountryNotesManager {
             assert false; // should always be a valid country
         }
         requireNonNull(countryNoteToDelete);
+        assert hasCountryNote(countryNoteToDelete);
 
-        //TODO: throw exception if country note not exist
-        if (hasCountryNote(countryNoteToDelete)) {
-            internalCountryNoteList.remove(countryNoteToDelete);
-        }
-
+        internalCountryNoteList.remove(countryNoteToDelete);
     }
 }

--- a/src/main/java/seedu/address/model/note/CountryNote.java
+++ b/src/main/java/seedu/address/model/note/CountryNote.java
@@ -53,4 +53,9 @@ public class CountryNote extends Note {
     public int hashCode() {
         return Objects.hash(super.hashCode(), country);
     }
+
+    @Override
+    public String toString() {
+        return super.toString() + " [" + getCountry() + "]";
+    }
 }

--- a/src/main/java/seedu/address/ui/CountryNoteCard.java
+++ b/src/main/java/seedu/address/ui/CountryNoteCard.java
@@ -32,6 +32,6 @@ public class CountryNoteCard extends UiPart<Region> {
         super(FXML);
         requireAllNonNull(index, countryNote);
         this.countryNote = countryNote;
-        countryNoteContent.setText(index + ". " + countryNote.getNoteContents());
+        countryNoteContent.setText(index + ". " + countryNote);
     }
 }

--- a/src/main/java/seedu/address/ui/CountryNoteListPanel.java
+++ b/src/main/java/seedu/address/ui/CountryNoteListPanel.java
@@ -39,7 +39,7 @@ public class CountryNoteListPanel extends UiPart<Region> {
      * @param country The country to be displayed.
      */
     public void setHeader(Country country) {
-        if (country == null) {
+        if (country.equals(Country.getNullCountry())) {
             header.setText("All Country Notes");
         } else {
             header.setText(country + " notes");

--- a/src/main/java/seedu/address/ui/CountryNoteListPanel.java
+++ b/src/main/java/seedu/address/ui/CountryNoteListPanel.java
@@ -39,7 +39,7 @@ public class CountryNoteListPanel extends UiPart<Region> {
      * @param country The country to be displayed.
      */
     public void setHeader(Country country) {
-        if (country.equals(Country.getNullCountry())) {
+        if (country.equals(Country.NULL_COUNTRY)) {
             header.setText("All Country Notes");
         } else {
             header.setText(country + " notes");

--- a/src/main/java/seedu/address/ui/CountryNoteListPanel.java
+++ b/src/main/java/seedu/address/ui/CountryNoteListPanel.java
@@ -33,6 +33,11 @@ public class CountryNoteListPanel extends UiPart<Region> {
         countryNoteListView.setCellFactory(listView -> new CountryListViewCell());
     }
 
+    /**
+     * Sets the header of the CountryNoteListPanel.
+     *
+     * @param country The country to be displayed.
+     */
     public void setHeader(Country country) {
         if (country == null) {
             header.setText("All Country Notes");

--- a/src/main/java/seedu/address/ui/CountryNoteListPanel.java
+++ b/src/main/java/seedu/address/ui/CountryNoteListPanel.java
@@ -7,6 +7,7 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
+import seedu.address.model.country.Country;
 import seedu.address.model.note.CountryNote;
 
 /**
@@ -30,6 +31,14 @@ public class CountryNoteListPanel extends UiPart<Region> {
         header.setText("Country Notes");
         countryNoteListView.setItems(countryNoteObservableList);
         countryNoteListView.setCellFactory(listView -> new CountryListViewCell());
+    }
+
+    public void setHeader(Country country) {
+        if (country == null) {
+            header.setText("All Country Notes");
+        } else {
+            header.setText(country + " notes");
+        }
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -186,7 +186,7 @@ public class MainWindow extends UiPart<Stage> {
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
-            logger.info("Widget View Option: " + commandResult.getWidgetViewOption());
+            logger.info("Widget View Option: " + commandResult.getWidgetViewOptionAsString());
 
             if (commandResult.shouldDisplayClient()) {
                 logger.info("Toggling client view");
@@ -196,7 +196,7 @@ public class MainWindow extends UiPart<Stage> {
             } else if (commandResult.shouldDisplayCountryNote()) {
                 logger.info("Toggling country notes view");
                 widgetPlaceholder.getChildren().clear();
-                countryNoteListPanel.setHeader(commandResult.getWidgetViewOption().getCountry());
+                countryNoteListPanel.setHeader(commandResult.getCountry());
                 widgetPlaceholder.getChildren().add(countryNoteListPanel.getRoot());
             }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -188,21 +188,16 @@ public class MainWindow extends UiPart<Stage> {
 
             logger.info("Widget View Option: " + commandResult.getWidgetViewOption());
 
-            switch (commandResult.getWidgetViewOption()) {
-            case CLIENT:
+            if (commandResult.shouldDisplayClient()) {
                 logger.info("Toggling client view");
                 widgetPlaceholder.getChildren().clear();
                 widgetPlaceholder.getChildren().add(widgetViewBox.getRoot());
                 widgetViewBox.update(logic.getWidgetContent());
-                break;
-            case COUNTRY_NOTES:
+            } else if (commandResult.shouldDisplayCountryNote()) {
                 logger.info("Toggling country notes view");
                 widgetPlaceholder.getChildren().clear();
+                countryNoteListPanel.setHeader(commandResult.getWidgetViewOption().getCountry());
                 widgetPlaceholder.getChildren().add(countryNoteListPanel.getRoot());
-                break;
-            case NONE:
-            default:
-                break;
             }
 
             if (commandResult.isShowHelp()) {

--- a/src/main/java/seedu/address/ui/WidgetViewOption.java
+++ b/src/main/java/seedu/address/ui/WidgetViewOption.java
@@ -34,7 +34,7 @@ public class WidgetViewOption {
      * @return A client widget option that represents intent to view client.
      */
     public static WidgetViewOption generateClientWidgetOption() {
-        return new WidgetViewOption(true, false, null);
+        return new WidgetViewOption(true, false, Country.getNullCountry());
     }
 
     /**
@@ -52,7 +52,7 @@ public class WidgetViewOption {
      * @return A null widget option.
      */
     public static WidgetViewOption generateNullWidgetOption() {
-        return new WidgetViewOption(false, false, null);
+        return new WidgetViewOption(false, false, Country.getNullCountry());
     }
 
     /**

--- a/src/main/java/seedu/address/ui/WidgetViewOption.java
+++ b/src/main/java/seedu/address/ui/WidgetViewOption.java
@@ -1,10 +1,43 @@
 package seedu.address.ui;
 
+import seedu.address.model.country.Country;
+
 /**
  * Represents the display option for the Widget View.
  */
-public enum WidgetViewOption {
-    CLIENT,
-    COUNTRY_NOTES,
-    NONE
+public class WidgetViewOption {
+    private final boolean isClient;
+    private final boolean isCountryNote;
+    private final Country country;
+
+    private WidgetViewOption(boolean isClient, boolean isCountryNote, Country country) {
+        assert !(isClient && isCountryNote); // isClient and isCountryNote cannot be both true
+        this.isClient = isClient;
+        this.isCountryNote = isCountryNote;
+        this.country = country;
+    }
+
+    public static WidgetViewOption generateClientWidgetOption() {
+        return new WidgetViewOption(true, false, null);
+    }
+
+    public static WidgetViewOption generateCountryNoteWidgetOption(Country country) {
+        return new WidgetViewOption(false, true, country);
+    }
+
+    public static WidgetViewOption generateNullWidgetOption() {
+        return new WidgetViewOption(false, false, null);
+    }
+
+    public boolean isClient() {
+        return isClient;
+    }
+
+    public boolean isCountryNote() {
+        return isCountryNote;
+    }
+
+    public Country getCountry() {
+        return country;
+    }
 }

--- a/src/main/java/seedu/address/ui/WidgetViewOption.java
+++ b/src/main/java/seedu/address/ui/WidgetViewOption.java
@@ -34,7 +34,7 @@ public class WidgetViewOption {
      * @return A client widget option that represents intent to view client.
      */
     public static WidgetViewOption generateClientWidgetOption() {
-        return new WidgetViewOption(true, false, Country.getNullCountry());
+        return new WidgetViewOption(true, false, Country.NULL_COUNTRY);
     }
 
     /**
@@ -52,7 +52,7 @@ public class WidgetViewOption {
      * @return A null widget option.
      */
     public static WidgetViewOption generateNullWidgetOption() {
-        return new WidgetViewOption(false, false, Country.getNullCountry());
+        return new WidgetViewOption(false, false, Country.NULL_COUNTRY);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/WidgetViewOption.java
+++ b/src/main/java/seedu/address/ui/WidgetViewOption.java
@@ -1,5 +1,7 @@
 package seedu.address.ui;
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.address.model.country.Country;
 
 /**
@@ -23,6 +25,8 @@ public class WidgetViewOption {
      */
     private WidgetViewOption(boolean isClient, boolean isCountryNote, Country country) {
         assert !(isClient && isCountryNote) : "isClient and isCountryNote cannot be both true";
+        requireNonNull(country);
+        assert !(isClient && isCountryNote); // isClient and isCountryNote cannot be both true
         this.isClient = isClient;
         this.isCountryNote = isCountryNote;
         this.country = country;

--- a/src/main/java/seedu/address/ui/WidgetViewOption.java
+++ b/src/main/java/seedu/address/ui/WidgetViewOption.java
@@ -6,10 +6,21 @@ import seedu.address.model.country.Country;
  * Represents the display option for the Widget View.
  */
 public class WidgetViewOption {
+    private static final String CLIENT = "CLIENT";
+    private static final String COUNTRY_NOTE = "COUNTRY_NOTE";
+    private static final String NONE = "NONE";
+
     private final boolean isClient;
     private final boolean isCountryNote;
     private final Country country;
 
+    /**
+     * Initializes a WidgetViewOption.
+     *
+     * @param isClient True if displaying client view.
+     * @param isCountryNote True if displaying country notes view.
+     * @param country The country of the country notes to view.
+     */
     private WidgetViewOption(boolean isClient, boolean isCountryNote, Country country) {
         assert !(isClient && isCountryNote); // isClient and isCountryNote cannot be both true
         this.isClient = isClient;
@@ -17,27 +28,68 @@ public class WidgetViewOption {
         this.country = country;
     }
 
+    /**
+     * Generates a client widget option that represents intent to view client.
+     *
+     * @return A client widget option that represents intent to view client.
+     */
     public static WidgetViewOption generateClientWidgetOption() {
         return new WidgetViewOption(true, false, null);
     }
 
+    /**
+     * Generates a country note widget option that represents intent to view country notes.
+     *
+     * @return A country note widget option that represents intent to view country notes.
+     */
     public static WidgetViewOption generateCountryNoteWidgetOption(Country country) {
         return new WidgetViewOption(false, true, country);
     }
 
+    /**
+     * Generates a null widget option.
+     *
+     * @return A null widget option.
+     */
     public static WidgetViewOption generateNullWidgetOption() {
         return new WidgetViewOption(false, false, null);
     }
 
+    /**
+     * Returns whether UI should display client view.
+     *
+     * @return True if UI should display client view.
+     */
     public boolean isClient() {
         return isClient;
     }
 
+    /**
+     * Returns whether UI should display country notes view.
+     *
+     * @return True if UI should display country notes view.
+     */
     public boolean isCountryNote() {
         return isCountryNote;
     }
 
+    /**
+     * Returns the country of the country notes.
+     *
+     * @return The country of the country notes.
+     */
     public Country getCountry() {
         return country;
+    }
+
+    @Override
+    public String toString() {
+        if (isClient) {
+            return CLIENT;
+        } else if (isCountryNote) {
+            return COUNTRY_NOTE;
+        } else {
+            return NONE;
+        }
     }
 }

--- a/src/main/java/seedu/address/ui/WidgetViewOption.java
+++ b/src/main/java/seedu/address/ui/WidgetViewOption.java
@@ -22,7 +22,7 @@ public class WidgetViewOption {
      * @param country The country of the country notes to view.
      */
     private WidgetViewOption(boolean isClient, boolean isCountryNote, Country country) {
-        assert !(isClient && isCountryNote); // isClient and isCountryNote cannot be both true
+        assert !(isClient && isCountryNote) : "isClient and isCountryNote cannot be both true";
         this.isClient = isClient;
         this.isCountryNote = isCountryNote;
         this.country = country;

--- a/src/test/java/seedu/address/logic/commands/ClientAddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClientAddCommandTest.java
@@ -215,6 +215,11 @@ public class ClientAddCommandTest {
         }
 
         @Override
+        public void deleteCountryNote(CountryNote countryNoteToDelete) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ObservableList<Client> getFilteredClientList() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -31,7 +31,7 @@ public class CommandResultTest {
         assertFalse(customCommandResult.shouldDisplayCountryNote());
 
         customCommandResult = new CommandResult("test", true, false,
-                WidgetViewOption.generateCountryNoteWidgetOption(null));
+                WidgetViewOption.generateCountryNoteWidgetOption(Country.NULL_COUNTRY));
         assertEquals("COUNTRY_NOTE", customCommandResult.getWidgetViewOptionAsString());
         assertFalse(customCommandResult.shouldDisplayClient());
         assertTrue(customCommandResult.shouldDisplayCountryNote());

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.country.Country;
 import seedu.address.ui.WidgetViewOption;
 
 public class CommandResultTest {
@@ -17,6 +18,8 @@ public class CommandResultTest {
         assertFalse(defaultCommandResult.isShowHelp());
         assertFalse(defaultCommandResult.isExit());
         assertEquals("NONE", defaultCommandResult.getWidgetViewOptionAsString());
+        assertFalse(defaultCommandResult.shouldDisplayClient());
+        assertFalse(defaultCommandResult.shouldDisplayCountryNote());
 
         CommandResult customCommandResult = new CommandResult("test", true, false,
                 WidgetViewOption.generateClientWidgetOption());
@@ -24,10 +27,28 @@ public class CommandResultTest {
         assertFalse(customCommandResult.isExit());
         assertEquals("CLIENT", customCommandResult.getWidgetViewOptionAsString());
         assertEquals(customCommandResult.getFeedbackToUser(), "test");
+        assertTrue(customCommandResult.shouldDisplayClient());
+        assertFalse(customCommandResult.shouldDisplayCountryNote());
 
         customCommandResult = new CommandResult("test", true, false,
                 WidgetViewOption.generateCountryNoteWidgetOption(null));
         assertEquals("COUNTRY_NOTE", customCommandResult.getWidgetViewOptionAsString());
+        assertFalse(customCommandResult.shouldDisplayClient());
+        assertTrue(customCommandResult.shouldDisplayCountryNote());
+    }
+
+    @Test
+    public void getCountry_nullCountry_returnExpected() {
+        CommandResult commandResult = new CommandResult("test", false, false,
+                WidgetViewOption.generateCountryNoteWidgetOption(Country.getNullCountry()));
+        assertEquals(Country.getNullCountry(), commandResult.getCountry());
+    }
+
+    @Test
+    public void getCountry_validCountry_returnExpected() {
+        CommandResult commandResult = new CommandResult("test", false, false,
+                WidgetViewOption.generateCountryNoteWidgetOption(new Country("SG")));
+        assertEquals(new Country("SG"), commandResult.getCountry());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -40,8 +40,8 @@ public class CommandResultTest {
     @Test
     public void getCountry_nullCountry_returnExpected() {
         CommandResult commandResult = new CommandResult("test", false, false,
-                WidgetViewOption.generateCountryNoteWidgetOption(Country.getNullCountry()));
-        assertEquals(Country.getNullCountry(), commandResult.getCountry());
+                WidgetViewOption.generateCountryNoteWidgetOption(Country.NULL_COUNTRY));
+        assertEquals(Country.NULL_COUNTRY, commandResult.getCountry());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -16,16 +16,18 @@ public class CommandResultTest {
         CommandResult defaultCommandResult = new CommandResult("test");
         assertFalse(defaultCommandResult.isShowHelp());
         assertFalse(defaultCommandResult.isExit());
-        assertEquals(WidgetViewOption.NONE, defaultCommandResult.getWidgetViewOption());
+        assertEquals("NONE", defaultCommandResult.getWidgetViewOptionAsString());
 
-        CommandResult customCommandResult = new CommandResult("test", true, false, WidgetViewOption.CLIENT);
+        CommandResult customCommandResult = new CommandResult("test", true, false,
+                WidgetViewOption.generateClientWidgetOption());
         assertTrue(customCommandResult.isShowHelp());
         assertFalse(customCommandResult.isExit());
-        assertEquals(WidgetViewOption.CLIENT, customCommandResult.getWidgetViewOption());
+        assertEquals("CLIENT", customCommandResult.getWidgetViewOptionAsString());
         assertEquals(customCommandResult.getFeedbackToUser(), "test");
 
-        customCommandResult = new CommandResult("test", true, false, WidgetViewOption.COUNTRY_NOTES);
-        assertEquals(WidgetViewOption.COUNTRY_NOTES, customCommandResult.getWidgetViewOption());
+        customCommandResult = new CommandResult("test", true, false,
+                WidgetViewOption.generateCountryNoteWidgetOption(null));
+        assertEquals("COUNTRY_NOTE", customCommandResult.getWidgetViewOptionAsString());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CountryNoteDeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CountryNoteDeleteCommandTest.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.country.Country;
+
+public class CountryNoteDeleteCommandTest {
+    @Test
+    public void equals_sameIndex_returnsTrue() {
+        Index index = Index.fromOneBased(1);
+        CountryNoteDeleteCommand first = new CountryNoteDeleteCommand(index);
+        CountryNoteDeleteCommand second = new CountryNoteDeleteCommand(index);
+        assertEquals(first, second);
+    }
+
+    @Test
+    public void equals_diffIndex_returnsFalse() {
+        Index index = Index.fromOneBased(1);
+        Index index2 = Index.fromOneBased(2);
+        CountryNoteDeleteCommand first = new CountryNoteDeleteCommand(index);
+        CountryNoteDeleteCommand second = new CountryNoteDeleteCommand(index2);
+        assertNotEquals(first, second);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CountryNoteDeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CountryNoteDeleteCommandTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.model.country.Country;
 
 public class CountryNoteDeleteCommandTest {
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -164,8 +164,6 @@ public class AddressBookParserTest {
         assertEquals(new ClientNoteAddCommand(INDEX_FIRST_CLIENT, note), command);
     }
 
-
-
     @Test
     public void parseClientNoteCommands_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -149,6 +149,8 @@ public class AddressBookParserTest {
                 parser.parseCommand("country unknownCommand "));
     }
 
+    //TODO: add tests when country commands are finalized
+
     @Test
     public void parseClientNoteCommands_addClientNote() throws Exception {
         final String noteString = "likes cats";
@@ -161,6 +163,8 @@ public class AddressBookParserTest {
         ClientNoteAddCommand command = (ClientNoteAddCommand) parser.parseCommand(commandString);
         assertEquals(new ClientNoteAddCommand(INDEX_FIRST_CLIENT, note), command);
     }
+
+
 
     @Test
     public void parseClientNoteCommands_unrecognisedInput_throwsParseException() {

--- a/src/test/java/seedu/address/logic/parser/CountryFilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CountryFilterCommandParserTest.java
@@ -21,6 +21,12 @@ public class CountryFilterCommandParserTest {
     }
 
     @Test
+    public void parse_withPreamable_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(" random string c/SG"));
+        assertThrows(ParseException.class, () -> parser.parse(" 123 c/MY"));
+    }
+
+    @Test
     public void parse_invalidCountryCode_throwsParseException() {
         assertThrows(ParseException.class, () -> parser.parse(" c/ZZ"));
         assertThrows(ParseException.class, () -> parser.parse(" c/123"));

--- a/src/test/java/seedu/address/logic/parser/CountryNoteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CountryNoteCommandParserTest.java
@@ -21,6 +21,18 @@ public class CountryNoteCommandParserTest {
     }
 
     @Test
+    public void parse_withPreamable_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(" random string c/SG nt/abc"));
+        assertThrows(ParseException.class, () -> parser.parse(" random string c/SG nt/"));
+        assertThrows(ParseException.class, () -> parser.parse(" random string c/ nt/abc"));
+        assertThrows(ParseException.class, () -> parser.parse(" random string c/ nt/"));
+        assertThrows(ParseException.class, () -> parser.parse(" 123 c/SG nt/abc"));
+        assertThrows(ParseException.class, () -> parser.parse(" 123 c/SG nt/"));
+        assertThrows(ParseException.class, () -> parser.parse(" 123 c/ nt/abc"));
+        assertThrows(ParseException.class, () -> parser.parse(" 123 c/ nt/"));
+    }
+
+    @Test
     public void parse_hasCountryNoNote_throwsParseException() {
         assertThrows(ParseException.class, () -> parser.parse(" c/SG random string"));
     }

--- a/src/test/java/seedu/address/logic/parser/CountryNoteDeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CountryNoteDeleteCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CountryNoteDeleteCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class CountryNoteDeleteCommandParserTest {
+    private final CountryNoteDeleteCommandParser parser = new CountryNoteDeleteCommandParser();
+
+    @Test
+    public void parse_noIndex_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(" random string"));
+        assertThrows(ParseException.class, () -> parser.parse(" 2123 21string"));
+        assertThrows(ParseException.class, () -> parser.parse(""));
+        assertThrows(ParseException.class, () -> parser.parse("  "));
+        assertThrows(ParseException.class, () -> parser.parse("   owej o23r "));
+    }
+
+    @Test
+    public void parse_validIndex_returnsExpected() {
+        try {
+            CountryNoteDeleteCommand expected = new CountryNoteDeleteCommand(Index.fromOneBased(1));
+            CountryNoteDeleteCommand actual = parser.parse(" 1");
+        } catch (Exception e) {
+            fail();
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/CountryNoteViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CountryNoteViewCommandParserTest.java
@@ -14,11 +14,6 @@ public class CountryNoteViewCommandParserTest {
 
     @Test
     public void parse_noCountry_throwParseException() {
-        assertThrows(ParseException.class, () -> new CountryNoteViewCommandParser().parse(" "));
-        assertThrows(ParseException.class, () -> new CountryNoteViewCommandParser().parse(" avbc"));
-        assertThrows(ParseException.class, () -> new CountryNoteViewCommandParser().parse(" sg"));
-        assertThrows(ParseException.class, () -> new CountryNoteViewCommandParser().parse(" SG"));
-        assertThrows(ParseException.class, () -> new CountryNoteViewCommandParser().parse(" 123"));
         assertThrows(ParseException.class, () -> new CountryNoteViewCommandParser().parse(" c/"));
         assertThrows(ParseException.class, () -> new CountryNoteViewCommandParser().parse(" c/   "));
         assertThrows(ParseException.class, () -> new CountryNoteViewCommandParser().parse(" c/   12"));

--- a/src/test/java/seedu/address/logic/parser/CountryNoteViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CountryNoteViewCommandParserTest.java
@@ -13,10 +13,25 @@ import seedu.address.model.country.Country;
 public class CountryNoteViewCommandParserTest {
 
     @Test
-    public void parse_noCountry_throwParseException() {
+    public void parse_invalidCountry_throwParseException() {
         assertThrows(ParseException.class, () -> new CountryNoteViewCommandParser().parse(" c/"));
         assertThrows(ParseException.class, () -> new CountryNoteViewCommandParser().parse(" c/   "));
         assertThrows(ParseException.class, () -> new CountryNoteViewCommandParser().parse(" c/   12"));
+    }
+
+    @Test
+    public void parse_noCountry_returnsExpected() {
+        CountryNoteViewCommand expected = new CountryNoteViewCommand();
+        try {
+            CountryNoteViewCommand actual = new CountryNoteViewCommandParser().parse("");
+            assertEquals(expected, actual);
+            actual = new CountryNoteViewCommandParser().parse(" awfoekwof owfofew  132");
+            assertEquals(expected, actual);
+            actual = new CountryNoteViewCommandParser().parse("  2  3");
+            assertEquals(expected, actual);
+        } catch (ParseException e) {
+            fail();
+        }
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/CountryNoteViewCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CountryNoteViewCommandParserTest.java
@@ -21,17 +21,20 @@ public class CountryNoteViewCommandParserTest {
 
     @Test
     public void parse_noCountry_returnsExpected() {
-        CountryNoteViewCommand expected = new CountryNoteViewCommand();
         try {
+            CountryNoteViewCommand expected = new CountryNoteViewCommand();
             CountryNoteViewCommand actual = new CountryNoteViewCommandParser().parse("");
-            assertEquals(expected, actual);
-            actual = new CountryNoteViewCommandParser().parse(" awfoekwof owfofew  132");
-            assertEquals(expected, actual);
-            actual = new CountryNoteViewCommandParser().parse("  2  3");
             assertEquals(expected, actual);
         } catch (ParseException e) {
             fail();
         }
+    }
+
+    @Test
+    public void parse_withPreamble_throwsParseException() {
+        assertThrows(ParseException.class, () -> new CountryNoteViewCommandParser().parse(" abc"));
+        assertThrows(ParseException.class, () -> new CountryNoteViewCommandParser().parse(" 12 32 2"));
+        assertThrows(ParseException.class, () -> new CountryNoteViewCommandParser().parse(" a 2 3b"));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -20,6 +20,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.client.Client;
 import seedu.address.model.client.exceptions.DuplicateClientException;
+import seedu.address.model.country.Country;
 import seedu.address.model.note.CountryNote;
 import seedu.address.model.note.Note;
 import seedu.address.testutil.ClientBuilder;
@@ -83,6 +84,24 @@ public class AddressBookTest {
     @Test
     public void getClientList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> addressBook.getClientList().remove(0));
+    }
+
+    @Test
+    public void addCountryNote_updateCountryNoteList() {
+        CountryNote countryNote = new CountryNote("random", new Country("SG"));
+        assertFalse(addressBook.hasCountryNote(countryNote));
+        addressBook.addCountryNote(countryNote);
+        assertTrue(addressBook.hasCountryNote(countryNote));
+    }
+
+    @Test
+    public void deleteCountryNote_updateCountryNoteList() {
+        CountryNote countryNote = new CountryNote("random2", new Country("SG"));
+        assertFalse(addressBook.hasCountryNote(countryNote));
+        addressBook.addCountryNote(countryNote);
+        assertTrue(addressBook.hasCountryNote(countryNote));
+        addressBook.deleteCountryNote(countryNote);
+        assertFalse(addressBook.hasCountryNote(countryNote));
     }
 
     /**

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -225,13 +225,23 @@ public class ModelManagerTest {
 
     @Test
     public void updateFilteredCountryNoteList_countryPredicate_showRelevantCountryNotes() {
+        modelManager.addCountryNote(new CountryNote("random", new Country("SG")));
         modelManager.updateFilteredCountryNoteList(countryNote -> true);
         int expect = (int) modelManager.getFilteredCountryNoteList()
                 .stream()
                 .filter(countryNote -> countryNote.getCountry().equals(new Country("SG")))
                 .count();
-        modelManager.updateFilteredCountryNoteList(countryNote -> countryNote.equals(new Country("SG")));
+        modelManager.updateFilteredCountryNoteList(countryNote -> countryNote.getCountry().equals(new Country("SG")));
         assertEquals(expect, modelManager.getFilteredCountryNoteList().size());
+    }
+
+    @Test
+    public void deleteCountryNote_validCountryNote_updateCountryNoteList() {
+        modelManager.addCountryNote(new CountryNote("random", new Country("SG")));
+        modelManager.updateFilteredCountryNoteList(countryNote -> true);
+        int initial = modelManager.getFilteredCountryNoteList().size();
+        modelManager.deleteCountryNote(modelManager.getFilteredCountryNoteList().get(0));
+        assertEquals(initial - 1, modelManager.getFilteredCountryNoteList().size());
     }
 
     /* todo future tests:

--- a/src/test/java/seedu/address/model/country/CountryNotesManagerTest.java
+++ b/src/test/java/seedu/address/model/country/CountryNotesManagerTest.java
@@ -2,6 +2,7 @@ package seedu.address.model.country;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Locale;
@@ -64,6 +65,23 @@ public class CountryNotesManagerTest {
                     .filter(x -> x.equals(genericNote))
                     .count());
         }
+    }
+
+    @Test
+    public void deleteCountryNote_countryNoteNotExist_assertionError() {
+        CountryNotesManager countryNotesManager = new CountryNotesManager();
+        CountryNote countryNote = new CountryNote("random", new Country("SG"));
+        assertThrows(AssertionError.class, () -> countryNotesManager.deleteCountryNote(countryNote));
+    }
+
+    @Test
+    public void deleteCountryNote_countryNoteExists_deletesCountryNote() {
+        CountryNotesManager countryNotesManager = new CountryNotesManager();
+        CountryNote countryNote = new CountryNote("random", new Country("SG"));
+        countryNotesManager.addCountryNote(countryNote);
+        assertTrue(countryNotesManager.hasCountryNote(countryNote));
+        countryNotesManager.deleteCountryNote(countryNote);
+        assertFalse(countryNotesManager.hasCountryNote(countryNote));
     }
 
 }

--- a/src/test/java/seedu/address/ui/WidgetViewOptionTest.java
+++ b/src/test/java/seedu/address/ui/WidgetViewOptionTest.java
@@ -1,0 +1,39 @@
+package seedu.address.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.country.Country;
+
+public class WidgetViewOptionTest {
+    @Test
+    public void generateClientWidgetOption_isClientTrue() {
+        WidgetViewOption widgetViewOption = WidgetViewOption.generateClientWidgetOption();
+        assertTrue(widgetViewOption.isClient());
+        assertFalse(widgetViewOption.isCountryNote());
+        assertEquals(Country.getNullCountry(), widgetViewOption.getCountry());
+    }
+
+    @Test
+    public void generateCountryNoteWidgetOption_isCountryNoteTrue() {
+        WidgetViewOption widgetViewOption = WidgetViewOption.generateCountryNoteWidgetOption(Country.getNullCountry());
+        assertFalse(widgetViewOption.isClient());
+        assertTrue(widgetViewOption.isCountryNote());
+        assertEquals(Country.getNullCountry(), widgetViewOption.getCountry());
+        widgetViewOption = WidgetViewOption.generateCountryNoteWidgetOption(new Country("SG"));
+        assertFalse(widgetViewOption.isClient());
+        assertTrue(widgetViewOption.isCountryNote());
+        assertEquals(new Country("SG"), widgetViewOption.getCountry());
+    }
+
+    @Test
+    public void generateNullWidgetOption_allFalse() {
+        WidgetViewOption widgetViewOption = WidgetViewOption.generateNullWidgetOption();
+        assertFalse(widgetViewOption.isClient());
+        assertFalse(widgetViewOption.isCountryNote());
+        assertEquals(Country.getNullCountry(), widgetViewOption.getCountry());
+    }
+}

--- a/src/test/java/seedu/address/ui/WidgetViewOptionTest.java
+++ b/src/test/java/seedu/address/ui/WidgetViewOptionTest.java
@@ -14,15 +14,15 @@ public class WidgetViewOptionTest {
         WidgetViewOption widgetViewOption = WidgetViewOption.generateClientWidgetOption();
         assertTrue(widgetViewOption.isClient());
         assertFalse(widgetViewOption.isCountryNote());
-        assertEquals(Country.getNullCountry(), widgetViewOption.getCountry());
+        assertEquals(Country.NULL_COUNTRY, widgetViewOption.getCountry());
     }
 
     @Test
     public void generateCountryNoteWidgetOption_isCountryNoteTrue() {
-        WidgetViewOption widgetViewOption = WidgetViewOption.generateCountryNoteWidgetOption(Country.getNullCountry());
+        WidgetViewOption widgetViewOption = WidgetViewOption.generateCountryNoteWidgetOption(Country.NULL_COUNTRY);
         assertFalse(widgetViewOption.isClient());
         assertTrue(widgetViewOption.isCountryNote());
-        assertEquals(Country.getNullCountry(), widgetViewOption.getCountry());
+        assertEquals(Country.NULL_COUNTRY, widgetViewOption.getCountry());
         widgetViewOption = WidgetViewOption.generateCountryNoteWidgetOption(new Country("SG"));
         assertFalse(widgetViewOption.isClient());
         assertTrue(widgetViewOption.isCountryNote());
@@ -34,6 +34,6 @@ public class WidgetViewOptionTest {
         WidgetViewOption widgetViewOption = WidgetViewOption.generateNullWidgetOption();
         assertFalse(widgetViewOption.isClient());
         assertFalse(widgetViewOption.isCountryNote());
-        assertEquals(Country.getNullCountry(), widgetViewOption.getCountry());
+        assertEquals(Country.NULL_COUNTRY, widgetViewOption.getCountry());
     }
 }


### PR DESCRIPTION
## Description

Implemented country note delete functionality. Basically followed the implementation of client delete.

Updated country note view to view all countries if no countries are specified (i.e. `country nview` would show all country notes). Else, the header will show the name of the country.

Fixes #222 

## Testing

Added standard tests for a new command.

## Remarks

NIL.
