### PR TITLE
Country note update

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -257,6 +257,16 @@ Examples:
 * `country note add c/CN nt/building good relations (guanxi) is important when conducting business here t/intercultural`
 * `country note add c/IN nt/is world's fastest growing economy`
 
+### Editing notes for a country: `country note edit`
+
+Edits a note that is associated with a specific country at the given index in the last viewed country note list panel.
+
+Format: `country note edit INDEX (nt/NOTE_STRING) (t/TAG)...`
+
+Example:
+
+* `country note edit 1 nt/new government policy to support local development in cloud security t/contract` Edits the country note at index 1 of the last-viewed country notes panel to have the content "new government policy to support local development in cloud security" and a new tag "contract" in addition to the previous tags.
+
 ### Deleting notes for a country: `country note delete`
 
 Deletes a note that is associated with a specific country.
@@ -320,6 +330,7 @@ Action | Format, Examples
 **Filter by country** | `country filter c/COUNTRY_CODE` <br> e.g., `country filter c/SG`
 **View country note** | `country note view [c/COUNTRY_CODE]` <br> e.g., `country note view c/SG`
 **Add country note** | `country note add c/COUNTRY_CODE nt/NOTE_STRING [t/TAG]...` <br> e.g., `country note add c/SG nt/has one of the lowest coporate taxes in the world t/tax`
+**Edit country note** | `country note edit INDEX (nt/NOTE_STRING) (t/TAG)...` <br> e.g., `country note edit 1 nt/has one of the lowest coporate taxes in the world t/tax`
 **Delete country note** | `country note delete INDEX` <br> e.g., `country note delete 1`
 **Get suggestions** | `suggest by/SUGGESTION_TYPE [by/SUGGESTION_TYPE]...` <br> e.g., `suggest by/available by/frequency`
 **Clear** | `clear`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -259,13 +259,15 @@ Examples:
 
 ### Editing notes for a country: `country note edit`
 
-Edits a note that is associated with a specific country at the given index in the last viewed country note list panel.
+Edits a note that is associated with a specific country at the given index in the last viewed country note list panel. 
+
+The country note list panel can be viewed using the command `country note view`.
 
 Format: `country note edit INDEX (nt/NOTE_STRING) (t/TAG)...`
 
 Example:
 
-* `country note edit 1 nt/new government policy to support local development in cloud security t/contract` Edits the country note at index 1 of the last-viewed country notes panel to have the content "new government policy to support local development in cloud security" and a new tag "contract" in addition to the previous tags.
+* `country note edit 1 nt/new government policy to support local development in cloud security t/contract` Edits the top-most country note in the last-viewed country notes panel to have the content "new government policy to support local development in cloud security" and a new tag "contract" in addition to the previous tags.
 
 ### Deleting notes for a country: `country note delete`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -267,7 +267,7 @@ Format: `country note edit INDEX (nt/NOTE_STRING) (t/TAG)...`
 
 Example:
 
-* `country note edit 1 nt/new government policy to support local development in cloud security t/contract` Edits the top-most country note in the last-viewed country notes panel to have the content "new government policy to support local development in cloud security" and a new tag "contract" in addition to the previous tags.
+* `country note edit 1 nt/new government policy to support local development in cloud security t/contract` Edits the first country note in the last-viewed country notes panel to have the content "new government policy to support local development in cloud security" and a new tag "contract" in addition to the previous tags.
 
 ### Deleting notes for a country: `country note delete`
 

--- a/src/main/java/seedu/address/logic/commands/CountryNoteDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteDeleteCommand.java
@@ -18,7 +18,7 @@ public class CountryNoteDeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "country note delete";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the country note that are associated with the last viewed country at the given index.\n"
+            + ": Deletes the country note at the given index in the last viewed country note list panel.\n"
             + "Parameters: INDEX\n"
             + "Example: " + COMMAND_WORD + " 1";
     public static final String MESSAGE_SUCCESS = "Deleted country note at index %1$s: %2$s";
@@ -30,6 +30,7 @@ public class CountryNoteDeleteCommand extends Command {
      * @param targetIndex The given targetIndex.
      */
     public CountryNoteDeleteCommand(Index targetIndex) {
+        requireNonNull(targetIndex);
         this.targetIndex = targetIndex;
     }
 

--- a/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
@@ -79,9 +79,10 @@ public class CountryNoteEditCommand extends Command {
             tags.remove(Tag.UNTAGGED);
         }
 
-        CountryNote newCountryNote = new CountryNote(countryNoteToEdit.getNoteContent(),
+        CountryNote newCountryNote = new CountryNote(
+                countryNote.equals(CountryNote.NULL_COUNTRY_NOTE)
+                        ? countryNoteToEdit.getNoteContent() : countryNote.getNoteContent(),
                 countryNoteToEdit.getCountry(), tags);
-        newCountryNote.setTags(tags);
 
         model.setCountryNote(countryNoteToEdit, newCountryNote);
 

--- a/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
@@ -26,11 +26,10 @@ public class CountryNoteEditCommand extends Command {
     public static final String COMMAND_WORD = "country note edit";
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Edits the country note at the given index in the last viewed country note list panel.\n"
-            + "Parameters: INDEX"
-            + PREFIX_NOTE + "NOTE_STRING"
-            + " [" + PREFIX_TAG + "TAG]...\n"
-            + "Example: " + COMMAND_WORD + " SG "
-            + "Example: " + COMMAND_WORD + " 1";
+            + "Parameters: INDEX "
+            + "(" + PREFIX_NOTE + "NOTE_STRING )"
+            + " (" + PREFIX_TAG + "TAG)...\n"
+            + "Example: " + COMMAND_WORD + " 1 " + PREFIX_NOTE + "better government stability in recent months";
     public static final String MESSAGE_SUCCESS = "Edited country note at index %1$s: %2$s";
     private final Index targetIndex;
     private final CountryNote countryNote;

--- a/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
@@ -110,6 +110,6 @@ public class CountryNoteEditCommand extends Command {
         // state check
         CountryNoteEditCommand c = (CountryNoteEditCommand) other;
 
-        return targetIndex.equals(c.targetIndex) && countryNote.equals(c.countryNote);
+        return targetIndex.equals(c.targetIndex) && countryNote.equals(c.countryNote) && tags.equals(c.tags);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
@@ -64,7 +64,7 @@ public class CountryNoteEditCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<CountryNote> lastShownList = model.getFilteredCountryNoteList();
+        List<CountryNote> lastShownList = model.getSortedFilteredCountryNoteList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_COUNTRY_NOTE_DISPLAYED_INDEX);

--- a/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.commons.core.Messages;
@@ -57,7 +58,7 @@ public class CountryNoteEditCommand extends Command {
     public CountryNoteEditCommand(Index targetIndex, Set<Tag> tags) {
         requireAllNonNull(targetIndex, tags);
         this.targetIndex = targetIndex;
-        this.countryNote = null;
+        this.countryNote = CountryNote.NULL_COUNTRY_NOTE;
         this.tags = tags;
     }
 
@@ -74,10 +75,10 @@ public class CountryNoteEditCommand extends Command {
         CountryNote newCountryNote;
         tags.addAll(countryNoteToEdit.getTags());
 
-        if (countryNote == null) {
+        if (countryNote.equals(CountryNote.NULL_COUNTRY_NOTE)) {
             newCountryNote = new CountryNote(countryNoteToEdit);
         } else {
-            newCountryNote = countryNote.set(countryNoteToEdit.getCountry());
+            newCountryNote = countryNote.setCountry(countryNoteToEdit.getCountry());
             tags.addAll(countryNote.getTags());
         }
 
@@ -85,7 +86,7 @@ public class CountryNoteEditCommand extends Command {
             tags.remove(Tag.UNTAGGED);
         }
 
-        newCountryNote = newCountryNote.set(countryNoteToEdit.getCountry());
+        newCountryNote = newCountryNote.setCountry(countryNoteToEdit.getCountry());
         newCountryNote.setTags(tags);
 
         model.setCountryNote(countryNoteToEdit, newCountryNote);
@@ -103,7 +104,7 @@ public class CountryNoteEditCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof CountryNoteDeleteCommand)) {
+        if (!(other instanceof CountryNoteEditCommand)) {
             return false;
         }
 
@@ -111,5 +112,10 @@ public class CountryNoteEditCommand extends Command {
         CountryNoteEditCommand c = (CountryNoteEditCommand) other;
 
         return targetIndex.equals(c.targetIndex) && countryNote.equals(c.countryNote) && tags.equals(c.tags);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(targetIndex, countryNote, tags);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
@@ -71,21 +71,16 @@ public class CountryNoteEditCommand extends Command {
         }
 
         CountryNote countryNoteToEdit = lastShownList.get(targetIndex.getZeroBased());
-        CountryNote newCountryNote;
         tags.addAll(countryNoteToEdit.getTags());
+        tags.addAll(countryNote.getTags());
 
-        if (countryNote.equals(CountryNote.NULL_COUNTRY_NOTE)) {
-            newCountryNote = new CountryNote(countryNoteToEdit);
-        } else {
-            newCountryNote = countryNote.setCountry(countryNoteToEdit.getCountry());
-            tags.addAll(countryNote.getTags());
-        }
-
+        // if previously note has UNTAGGED and now it has additional tags, remove UNTAGGED
         if (tags.size() > 1 && tags.contains(Tag.UNTAGGED)) {
             tags.remove(Tag.UNTAGGED);
         }
 
-        newCountryNote = newCountryNote.setCountry(countryNoteToEdit.getCountry());
+        CountryNote newCountryNote = new CountryNote(countryNoteToEdit.getNoteContent(),
+                countryNoteToEdit.getCountry(), tags);
         newCountryNote.setTags(tags);
 
         model.setCountryNote(countryNoteToEdit, newCountryNote);

--- a/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
@@ -1,0 +1,94 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.note.CountryNote;
+import seedu.address.model.tag.Tag;
+import seedu.address.ui.WidgetViewOption;
+
+/**
+ * A class that encapsulates the logic for editing country notes.
+ */
+public class CountryNoteEditCommand extends Command {
+
+    public static final String COMMAND_WORD = "country note edit";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Edits the country note at the given index in the last viewed country note list panel.\n"
+            + "Parameters: INDEX"
+            + PREFIX_NOTE + "NOTE_STRING"
+            + " [" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " SG "
+            + "Example: " + COMMAND_WORD + " 1";
+    public static final String MESSAGE_SUCCESS = "Edited country note at index %1$s: %2$s";
+    private final Index targetIndex;
+    private final CountryNote countryNote;
+
+    /**
+     * Initializes a CountryNoteDeleteCommand with the given targetIndex.
+     *
+     * @param targetIndex The given targetIndex.
+     * @param countryNote The country note that contains the new note content.
+     */
+    public CountryNoteEditCommand(Index targetIndex, CountryNote countryNote) {
+        requireNonNull(targetIndex);
+        this.targetIndex = targetIndex;
+        this.countryNote = countryNote;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<CountryNote> lastShownList = model.getFilteredCountryNoteList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_COUNTRY_NOTE_DISPLAYED_INDEX);
+        }
+
+        CountryNote countryNoteToEdit = lastShownList.get(targetIndex.getZeroBased());
+
+        CountryNote newCountryNote = countryNote.set(countryNoteToEdit.getCountry());
+        Set<Tag> tags = new HashSet<>();
+        tags.addAll(countryNote.getTags());
+        tags.addAll(countryNoteToEdit.getTags());
+        if (tags.size() > 1 && tags.contains(Tag.UNTAGGED)) {
+            tags.remove(Tag.UNTAGGED);
+        }
+
+        newCountryNote = newCountryNote.set(countryNoteToEdit.getCountry());
+        newCountryNote.setTags(tags);
+
+        model.setCountryNote(countryNoteToEdit, newCountryNote);
+
+        return new CommandResult(
+                String.format(MESSAGE_SUCCESS, targetIndex.getOneBased(), newCountryNote), false, false,
+                WidgetViewOption.generateNullWidgetOption());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof CountryNoteDeleteCommand)) {
+            return false;
+        }
+
+        // state check
+        CountryNoteEditCommand c = (CountryNoteEditCommand) other;
+
+        return targetIndex.equals(c.targetIndex) && countryNote.equals(c.countryNote);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
@@ -75,7 +75,7 @@ public class CountryNoteEditCommand extends Command {
         tags.addAll(countryNote.getTags());
 
         // if previously note has UNTAGGED and now it has additional tags, remove UNTAGGED
-        if (tags.size() > 1 && tags.contains(Tag.UNTAGGED)) {
+        if (tags.size() > 1) {
             tags.remove(Tag.UNTAGGED);
         }
 

--- a/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -32,17 +33,32 @@ public class CountryNoteEditCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Edited country note at index %1$s: %2$s";
     private final Index targetIndex;
     private final CountryNote countryNote;
+    private final Set<Tag> tags;
 
     /**
-     * Initializes a CountryNoteDeleteCommand with the given targetIndex.
+     * Initializes a CountryNoteEditCommand with the given targetIndex.
      *
      * @param targetIndex The given targetIndex.
      * @param countryNote The country note that contains the new note content.
      */
     public CountryNoteEditCommand(Index targetIndex, CountryNote countryNote) {
-        requireNonNull(targetIndex);
+        requireAllNonNull(targetIndex);
         this.targetIndex = targetIndex;
         this.countryNote = countryNote;
+        this.tags = new HashSet<>();
+    }
+
+    /**
+     * Initializes a CountryNoteEditCommand with the given targetIndex.
+     *
+     * @param targetIndex The given targetIndex.
+     * @param tags The new tags to add to the country note at the existing targetIndex.
+     */
+    public CountryNoteEditCommand(Index targetIndex, Set<Tag> tags) {
+        requireAllNonNull(targetIndex, tags);
+        this.targetIndex = targetIndex;
+        this.countryNote = null;
+        this.tags = tags;
     }
 
     @Override
@@ -55,11 +71,16 @@ public class CountryNoteEditCommand extends Command {
         }
 
         CountryNote countryNoteToEdit = lastShownList.get(targetIndex.getZeroBased());
-
-        CountryNote newCountryNote = countryNote.set(countryNoteToEdit.getCountry());
-        Set<Tag> tags = new HashSet<>();
-        tags.addAll(countryNote.getTags());
+        CountryNote newCountryNote;
         tags.addAll(countryNoteToEdit.getTags());
+
+        if (countryNote == null) {
+            newCountryNote = new CountryNote(countryNoteToEdit);
+        } else {
+            newCountryNote = countryNote.set(countryNoteToEdit.getCountry());
+            tags.addAll(countryNote.getTags());
+        }
+
         if (tags.size() > 1 && tags.contains(Tag.UNTAGGED)) {
             tags.remove(Tag.UNTAGGED);
         }

--- a/src/main/java/seedu/address/logic/parser/CountryNoteEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CountryNoteEditCommandParser.java
@@ -37,7 +37,8 @@ public class CountryNoteEditCommandParser implements Parser<CountryNoteEditComma
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NOTE, PREFIX_TAG);
 
-        if (argMultimap.getValue(PREFIX_NOTE).isEmpty() || argMultimap.getPreamble().isEmpty()) {
+        if ((argMultimap.getValue(PREFIX_NOTE).isEmpty() && argMultimap.getValue(PREFIX_TAG).isEmpty())
+                || argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     CountryNoteEditCommand.MESSAGE_USAGE));
         }
@@ -47,6 +48,10 @@ public class CountryNoteEditCommandParser implements Parser<CountryNoteEditComma
         Set<Tag> tags = new HashSet<>();
         if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
             tags.addAll(tagNoteMap.getUniqueTags(argMultimap.getAllValues(PREFIX_TAG)));
+        }
+
+        if (argMultimap.getValue(PREFIX_NOTE).isEmpty()) {
+            return new CountryNoteEditCommand(targetIndex, tags);
         }
 
         Note note = ParserUtil.parseNote(argMultimap.getValue(PREFIX_NOTE).get());

--- a/src/main/java/seedu/address/logic/parser/CountryNoteEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CountryNoteEditCommandParser.java
@@ -55,8 +55,7 @@ public class CountryNoteEditCommandParser implements Parser<CountryNoteEditComma
         }
 
         Note note = ParserUtil.parseNote(argMultimap.getValue(PREFIX_NOTE).get());
-        CountryNote countryNote = new CountryNote(note.getNoteContent(), Country.NULL_COUNTRY);
-        countryNote.setTags(tags);
+        CountryNote countryNote = new CountryNote(note.getNoteContent(), Country.NULL_COUNTRY, tags);
 
         return new CountryNoteEditCommand(targetIndex, countryNote);
     }

--- a/src/main/java/seedu/address/logic/parser/CountryNoteEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CountryNoteEditCommandParser.java
@@ -18,7 +18,7 @@ import seedu.address.model.note.TagNoteMap;
 import seedu.address.model.tag.Tag;
 
 /**
- * Parses input arguments and creates a new CountryNoteEditCommandParser object.
+ * Parses input arguments and creates a new CountryNoteEditCommand object.
  */
 public class CountryNoteEditCommandParser implements Parser<CountryNoteEditCommand> {
 

--- a/src/main/java/seedu/address/logic/parser/CountryNoteEditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CountryNoteEditCommandParser.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CountryNoteEditCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.country.Country;
+import seedu.address.model.note.CountryNote;
+import seedu.address.model.note.Note;
+import seedu.address.model.note.TagNoteMap;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input arguments and creates a new CountryNoteEditCommandParser object.
+ */
+public class CountryNoteEditCommandParser implements Parser<CountryNoteEditCommand> {
+
+    private final TagNoteMap tagNoteMap;
+
+    /**
+     * Initializes a {@code CountryNoteEditCommandParser} with the {@code tagNoteMap} object.
+     */
+    public CountryNoteEditCommandParser(TagNoteMap tagNoteMap) {
+        requireNonNull(tagNoteMap);
+        this.tagNoteMap = tagNoteMap;
+    }
+
+    @Override
+    public CountryNoteEditCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NOTE, PREFIX_TAG);
+
+        if (argMultimap.getValue(PREFIX_NOTE).isEmpty() || argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    CountryNoteEditCommand.MESSAGE_USAGE));
+        }
+
+        Index targetIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
+
+        Set<Tag> tags = new HashSet<>();
+        if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            tags.addAll(tagNoteMap.getUniqueTags(argMultimap.getAllValues(PREFIX_TAG)));
+        }
+
+        Note note = ParserUtil.parseNote(argMultimap.getValue(PREFIX_NOTE).get());
+        CountryNote countryNote = new CountryNote(note.getNoteContent(), Country.NULL_COUNTRY);
+        countryNote.setTags(tags);
+
+        return new CountryNoteEditCommand(targetIndex, countryNote);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/MainParser.java
+++ b/src/main/java/seedu/address/logic/parser/MainParser.java
@@ -21,6 +21,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CountryFilterCommand;
 import seedu.address.logic.commands.CountryNoteAddCommand;
 import seedu.address.logic.commands.CountryNoteDeleteCommand;
+import seedu.address.logic.commands.CountryNoteEditCommand;
 import seedu.address.logic.commands.CountryNoteViewCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -158,6 +159,9 @@ public class MainParser {
 
         case CountryNoteDeleteCommand.COMMAND_WORD:
             return new CountryNoteDeleteCommandParser().parse(restOfCommand);
+
+        case CountryNoteEditCommand.COMMAND_WORD:
+            return new CountryNoteEditCommandParser(tagNoteMap).parse(restOfCommand);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -117,6 +117,11 @@ public interface Model {
     void deleteCountryNote(CountryNote countryNoteToDelete);
 
     /**
+     * Replaces the given old country note with the given new country note.
+     */
+    void setCountryNote(CountryNote oldCountryNote, CountryNote newCountryNote);
+
+    /**
      * Returns true if {@code client} contains the {@code clientNote} specified.
      */
     boolean hasClientNote(Client client, Note clientNote);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -177,6 +177,13 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void setCountryNote(CountryNote oldCountryNote, CountryNote newCountryNote) {
+        requireAllNonNull(oldCountryNote, newCountryNote);
+        this.tagNoteMap.editNote(oldCountryNote, newCountryNote);
+        tbmManager.setCountryNote(oldCountryNote, newCountryNote);
+    }
+
+    @Override
     public void addClientNote(Client target, Note clientNote) {
         requireAllNonNull(target, clientNote);
         target.addClientNote(clientNote);

--- a/src/main/java/seedu/address/model/TbmManager.java
+++ b/src/main/java/seedu/address/model/TbmManager.java
@@ -148,6 +148,17 @@ public class TbmManager implements ReadOnlyTbmManager {
     }
 
     /**
+     * Replaces the old country note with the new country note.
+     *
+     * @param oldCountryNote The old country note.
+     * @param newCountryNote The new country note that replaces the old country note.
+     */
+    public void setCountryNote(CountryNote oldCountryNote, CountryNote newCountryNote) {
+        requireAllNonNull(oldCountryNote, newCountryNote);
+        countryNotesManager.setCountryNote(oldCountryNote, newCountryNote);
+    }
+
+    /**
      * Deletes the given country note.
      *
      * @param countryNoteToDelete The country note to delete.

--- a/src/main/java/seedu/address/model/country/CountryNotesManager.java
+++ b/src/main/java/seedu/address/model/country/CountryNotesManager.java
@@ -79,7 +79,7 @@ public class CountryNotesManager {
      * @param newCountryNote The new country note.
      */
     public void setCountryNote(CountryNote oldCountryNote, CountryNote newCountryNote) {
-        assert hasCountryNote(oldCountryNote) : "old country note must exist in internal list";;
+        assert hasCountryNote(oldCountryNote) : "old country note must exist in internal list";
         int targetIndx = internalCountryNoteList.indexOf(oldCountryNote);
         internalCountryNoteList.set(targetIndx, newCountryNote);
     }

--- a/src/main/java/seedu/address/model/country/CountryNotesManager.java
+++ b/src/main/java/seedu/address/model/country/CountryNotesManager.java
@@ -79,8 +79,8 @@ public class CountryNotesManager {
      * @param newCountryNote The new country note.
      */
     public void setCountryNote(CountryNote oldCountryNote, CountryNote newCountryNote) {
+        assert hasCountryNote(oldCountryNote) : "old country note must exist in internal list";;
         int targetIndx = internalCountryNoteList.indexOf(oldCountryNote);
-        assert targetIndx >= 0 : "old country note must exist in internal list";
         internalCountryNoteList.set(targetIndx, newCountryNote);
     }
 

--- a/src/main/java/seedu/address/model/country/CountryNotesManager.java
+++ b/src/main/java/seedu/address/model/country/CountryNotesManager.java
@@ -72,6 +72,18 @@ public class CountryNotesManager {
         internalCountryNoteList.remove(countryNoteToDelete);
     }
 
+    /**
+     * Replaces the old country note with the new country note.
+     *
+     * @param oldCountryNote The old country note.
+     * @param newCountryNote The new country note.
+     */
+    public void setCountryNote(CountryNote oldCountryNote, CountryNote newCountryNote) {
+        int targetIndx = internalCountryNoteList.indexOf(oldCountryNote);
+        assert targetIndx >= 0 : "old country note must exist in internal list";
+        internalCountryNoteList.set(targetIndx, newCountryNote);
+    }
+
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object

--- a/src/main/java/seedu/address/model/note/CountryNote.java
+++ b/src/main/java/seedu/address/model/note/CountryNote.java
@@ -27,6 +27,16 @@ public class CountryNote extends Note implements Comparable<CountryNote> {
     }
 
     /**
+     * Initializes a country note by deep copying the given country note.
+     *
+     * @param countryNote The country note to deep copy.
+     */
+    public CountryNote(CountryNote countryNote) {
+        super(countryNote.getNoteContent());
+        this.country = countryNote.country;
+    }
+
+    /**
      * Gets the country that is being associated with this country note.
      *
      * @return The country that is being associated with this country note.
@@ -42,6 +52,7 @@ public class CountryNote extends Note implements Comparable<CountryNote> {
      * @return A new country note with the country set as the given country.
      */
     public CountryNote set(Country country) {
+        requireNonNull(country);
         return new CountryNote(getNoteContent(), country);
     }
 

--- a/src/main/java/seedu/address/model/note/CountryNote.java
+++ b/src/main/java/seedu/address/model/note/CountryNote.java
@@ -1,10 +1,13 @@
 package seedu.address.model.note;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Objects;
+import java.util.Set;
 
 import seedu.address.model.country.Country;
+import seedu.address.model.tag.Tag;
 
 /**
  * Representation of a country note.
@@ -29,13 +32,17 @@ public class CountryNote extends Note implements Comparable<CountryNote> {
     }
 
     /**
-     * Initializes a country note by deep copying the given country note.
+     * Initializes the country note with the given content, country and tags.
      *
-     * @param countryNote The country note to deep copy.
+     * @param content The content of the country note.
+     * @param country The country that the country note belongs to.
+     * @param tags The tags that are associated with the country note.
      */
-    public CountryNote(CountryNote countryNote) {
-        super(countryNote.getNoteContent());
-        this.country = countryNote.country;
+    public CountryNote(String content, Country country, Set<Tag> tags) {
+        super(content);
+        requireAllNonNull(content, country, tags);
+        this.country = country;
+        super.setTags(tags);
     }
 
     /**
@@ -45,17 +52,6 @@ public class CountryNote extends Note implements Comparable<CountryNote> {
      */
     public Country getCountry() {
         return country;
-    }
-
-    /**
-     * Returns a new country note with the country set as the given country.
-     *
-     * @param country The given country.
-     * @return A new country note with the country set as the given country.
-     */
-    public CountryNote setCountry(Country country) {
-        requireNonNull(country);
-        return new CountryNote(getNoteContent(), country);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/note/CountryNote.java
+++ b/src/main/java/seedu/address/model/note/CountryNote.java
@@ -35,6 +35,16 @@ public class CountryNote extends Note implements Comparable<CountryNote> {
         return country;
     }
 
+    /**
+     * Returns a new country note with the country set as the given country.
+     *
+     * @param country The given country.
+     * @return A new country note with the country set as the given country.
+     */
+    public CountryNote set(Country country) {
+        return new CountryNote(getNoteContent(), country);
+    }
+
     @Override
     public boolean isClientNote() {
         return false;

--- a/src/main/java/seedu/address/model/note/CountryNote.java
+++ b/src/main/java/seedu/address/model/note/CountryNote.java
@@ -10,6 +10,7 @@ import seedu.address.model.country.Country;
  * Representation of a country note.
  */
 public class CountryNote extends Note implements Comparable<CountryNote> {
+    public static CountryNote NULL_COUNTRY_NOTE = new CountryNote("", Country.NULL_COUNTRY);
 
     private final Country country;
 
@@ -51,7 +52,7 @@ public class CountryNote extends Note implements Comparable<CountryNote> {
      * @param country The given country.
      * @return A new country note with the country set as the given country.
      */
-    public CountryNote set(Country country) {
+    public CountryNote setCountry(Country country) {
         requireNonNull(country);
         return new CountryNote(getNoteContent(), country);
     }

--- a/src/main/java/seedu/address/model/note/CountryNote.java
+++ b/src/main/java/seedu/address/model/note/CountryNote.java
@@ -10,7 +10,8 @@ import seedu.address.model.country.Country;
  * Representation of a country note.
  */
 public class CountryNote extends Note implements Comparable<CountryNote> {
-    public static CountryNote NULL_COUNTRY_NOTE = new CountryNote("", Country.NULL_COUNTRY);
+
+    public static final CountryNote NULL_COUNTRY_NOTE = new CountryNote("", Country.NULL_COUNTRY);
 
     private final Country country;
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -72,10 +72,6 @@ public class SampleDataUtil {
         for (Note note: getSampleClientNotes()) {
         }
 
-        for (CountryNote countryNote : getSampleCountryNotes()) {
-            sampleTm.addCountryNote(countryNote);
-        }
-
         return sampleTm;
     }
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedNote.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedNote.java
@@ -62,16 +62,19 @@ class JsonAdaptedNote {
      * @throws IllegalValueException if there were any data constraints violated in the adapted note.
      */
     public Note toModelType() throws IllegalValueException {
+        Set<Tag> tags = new HashSet<>();
+        for (JsonAdaptedTag tag : this.tags) {
+            tags.add(tag.toModelType());
+        }
+
         if (isClientNote()) {
-            Set<Tag> clientNoteTags = new HashSet<>();
-            for (JsonAdaptedTag tag : this.tags) {
-                clientNoteTags.add(tag.toModelType());
-            }
             Note clientNote = new Note(contents);
-            clientNote.setTags(clientNoteTags);
+            clientNote.setTags(tags);
             return clientNote;
         } else {
-            return new CountryNote(contents, new Country(countryCode));
+            CountryNote countryNote = new CountryNote(contents, new Country(countryCode));
+            countryNote.setTags(tags);
+            return countryNote;
         }
     }
 

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -34,7 +34,8 @@ public class HelpWindow extends UiPart<Stage> {
             + "country filter c/COUNTRY_CODE\n"
             + "country note view [c/COUNTRY_CODE]\n"
             + "country note add c/COUNTRY_CODE nt/NOTE_STRING [t/TAG]...\n"
-            + "country note delete INDEX";
+            + "country note delete INDEX\n"
+            + "country note edit INDEX (nt/NOTE_STRING) (t/TAG)...";
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";

--- a/src/test/java/seedu/address/logic/commands/ClientAddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClientAddCommandTest.java
@@ -206,6 +206,11 @@ public class ClientAddCommandTest {
         }
 
         @Override
+        public void setCountryNote(CountryNote oldCountryNote, CountryNote newCountryNote) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void addClientNote(Client client, Note clientNote) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/CountryNoteEditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CountryNoteEditCommandTest.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.country.Country;
+import seedu.address.model.note.CountryNote;
+import seedu.address.model.tag.Tag;
+
+public class CountryNoteEditCommandTest {
+    @Test
+    public void equals_allEqual_equal() {
+        CountryNoteEditCommand expected = new CountryNoteEditCommand(Index.fromOneBased(1),
+                new CountryNote("abc", Country.NULL_COUNTRY));
+        CountryNoteEditCommand actual = new CountryNoteEditCommand(Index.fromOneBased(1),
+                new CountryNote("abc", Country.NULL_COUNTRY));
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void equals_diffIndex_notEqual() {
+        CountryNoteEditCommand expected = new CountryNoteEditCommand(Index.fromOneBased(1),
+                new CountryNote("abc", Country.NULL_COUNTRY));
+        CountryNoteEditCommand actual = new CountryNoteEditCommand(Index.fromOneBased(2),
+                new CountryNote("abc", Country.NULL_COUNTRY));
+        assertNotEquals(expected, actual);
+    }
+
+    @Test
+    public void equals_diffCountryNote_notEqual() {
+        CountryNoteEditCommand expected = new CountryNoteEditCommand(Index.fromOneBased(1),
+                new CountryNote("abcd", Country.NULL_COUNTRY));
+        CountryNoteEditCommand actual = new CountryNoteEditCommand(Index.fromOneBased(1),
+                new CountryNote("abc", Country.NULL_COUNTRY));
+        assertNotEquals(expected, actual);
+    }
+
+    @Test
+    public void equals_sameTags_equal() {
+        CountryNoteEditCommand expected = new CountryNoteEditCommand(Index.fromOneBased(1), new HashSet<>());
+        CountryNoteEditCommand actual = new CountryNoteEditCommand(Index.fromOneBased(1), new HashSet<>());
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void equals_diffTags_equal() {
+        Set<Tag> tags = new HashSet<>();
+        tags.add(new Tag("a"));
+        CountryNoteEditCommand expected = new CountryNoteEditCommand(Index.fromOneBased(1), tags);
+        CountryNoteEditCommand actual = new CountryNoteEditCommand(Index.fromOneBased(1), new HashSet<>());
+        assertNotEquals(expected, actual);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/CountryNoteEditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CountryNoteEditCommandParserTest.java
@@ -17,16 +17,18 @@ import seedu.address.model.tag.Tag;
 
 public class CountryNoteEditCommandParserTest {
 
-    private final TagNoteMap tagNoteMap = new TagNoteMap();
-    private final CountryNoteEditCommandParser parser = new CountryNoteEditCommandParser(tagNoteMap);
     private static final String INVALID_COMMAND_ERROR = "Invalid command format! \n"
             + "country note edit: "
             + "Edits the country note at the given index in the last viewed country note list panel.\n"
             + "Parameters: INDEX (nt/NOTE_STRING ) (t/TAG)...\n"
             + "Example: country note edit 1 nt/better government stability in recent months";
     private static final String INVALID_INDEX_ERROR = "Index is not a non-zero unsigned integer.";
-    private static final String INVALID_TAG_ERROR = "Tags names should be alphanumeric and have a maximum of 45 characters";
+    private static final String INVALID_TAG_ERROR = "Tags names should be alphanumeric "
+            + "and have a maximum of 45 characters";
     private static final String INVALID_NOTE_ERROR = "Notes should not be blank";
+    private final TagNoteMap tagNoteMap = new TagNoteMap();
+    private final CountryNoteEditCommandParser parser = new CountryNoteEditCommandParser(tagNoteMap);
+
 
     @Test
     public void parse_withIndexWithNoteWithTag_returnsExpected() {

--- a/src/test/java/seedu/address/logic/parser/CountryNoteEditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CountryNoteEditCommandParserTest.java
@@ -19,14 +19,14 @@ public class CountryNoteEditCommandParserTest {
 
     private final TagNoteMap tagNoteMap = new TagNoteMap();
     private final CountryNoteEditCommandParser parser = new CountryNoteEditCommandParser(tagNoteMap);
-    private final String invalidCommandError = "Invalid command format! \n"
+    private static final String INVALID_COMMAND_ERROR = "Invalid command format! \n"
             + "country note edit: "
             + "Edits the country note at the given index in the last viewed country note list panel.\n"
             + "Parameters: INDEX (nt/NOTE_STRING ) (t/TAG)...\n"
             + "Example: country note edit 1 nt/better government stability in recent months";
-    private final String invalidIndexError = "Index is not a non-zero unsigned integer.";
-    private final String invalidTagError = "Tags names should be alphanumeric and have a maximum of 45 characters";
-    private final String invalidNoteError = "Notes should not be blank";
+    private static final String INVALID_INDEX_ERROR = "Index is not a non-zero unsigned integer.";
+    private static final String INVALID_TAG_ERROR = "Tags names should be alphanumeric and have a maximum of 45 characters";
+    private static final String INVALID_NOTE_ERROR = "Notes should not be blank";
 
     @Test
     public void parse_withIndexWithNoteWithTag_returnsExpected() {
@@ -41,18 +41,18 @@ public class CountryNoteEditCommandParserTest {
 
     @Test
     public void parse_noIndexWithNoteNoTag_throwsParseException() {
-        assertParseFailure(parser, " nt/abc", invalidCommandError);
-        assertParseFailure(parser, " nt/y", invalidCommandError);
-        assertParseFailure(parser, " abc nt/abc", invalidIndexError);
-        assertParseFailure(parser, " a 1 a nt/abc", invalidIndexError);
+        assertParseFailure(parser, " nt/abc", INVALID_COMMAND_ERROR);
+        assertParseFailure(parser, " nt/y", INVALID_COMMAND_ERROR);
+        assertParseFailure(parser, " abc nt/abc", INVALID_INDEX_ERROR);
+        assertParseFailure(parser, " a 1 a nt/abc", INVALID_INDEX_ERROR);
     }
 
     @Test
     public void parse_withIndexNoNoteNoTag_throwsParseException() {
-        assertParseFailure(parser, " 1  ", invalidCommandError);
-        assertParseFailure(parser, " 1 t/", invalidTagError);
-        assertParseFailure(parser, " 1 nt/", invalidNoteError);
-        assertParseFailure(parser, " 1 nt/ t/", invalidTagError);
+        assertParseFailure(parser, " 1  ", INVALID_COMMAND_ERROR);
+        assertParseFailure(parser, " 1 t/", INVALID_TAG_ERROR);
+        assertParseFailure(parser, " 1 nt/", INVALID_NOTE_ERROR);
+        assertParseFailure(parser, " 1 nt/ t/", INVALID_TAG_ERROR);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/CountryNoteEditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CountryNoteEditCommandParserTest.java
@@ -23,7 +23,7 @@ public class CountryNoteEditCommandParserTest {
     private final CountryNoteEditCommandParser parser = new CountryNoteEditCommandParser(tagNoteMap);
 
     @Test
-    public void parse_WithIndexWithNoteWithTag_returnsExpected() {
+    public void parse_withIndexWithNoteWithTag_returnsExpected() {
         try {
             CountryNote c = new CountryNote("abc", Country.NULL_COUNTRY);
             Set<Tag> tags = new HashSet<>();

--- a/src/test/java/seedu/address/logic/parser/CountryNoteEditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CountryNoteEditCommandParserTest.java
@@ -1,8 +1,7 @@
 package seedu.address.logic.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -11,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.CountryNoteEditCommand;
-import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.country.Country;
 import seedu.address.model.note.CountryNote;
 import seedu.address.model.note.TagNoteMap;
@@ -21,37 +19,39 @@ public class CountryNoteEditCommandParserTest {
 
     private final TagNoteMap tagNoteMap = new TagNoteMap();
     private final CountryNoteEditCommandParser parser = new CountryNoteEditCommandParser(tagNoteMap);
+    private final String invalidCommandError = "Invalid command format! \n"
+            + "country note edit: Edits the country note at the given index in the last viewed country note list panel.\n"
+            + "Parameters: INDEX (nt/NOTE_STRING ) (t/TAG)...\n"
+            + "Example: country note edit 1 nt/better government stability in recent months";
+    private final String invalidIndexError = "Index is not a non-zero unsigned integer.";
+    private final String invalidTagError = "Tags names should be alphanumeric and have a maximum of 45 characters";
+    private final String invalidNoteError = "Notes should not be blank";
 
     @Test
     public void parse_withIndexWithNoteWithTag_returnsExpected() {
-        try {
-            CountryNote c = new CountryNote("abc", Country.NULL_COUNTRY);
-            Set<Tag> tags = new HashSet<>();
-            tags.add(new Tag("a"));
-            c.setTags(tags);
-            CountryNoteEditCommand expected = new CountryNoteEditCommand(Index.fromOneBased(1), c);
+        CountryNote c = new CountryNote("abc", Country.NULL_COUNTRY);
+        Set<Tag> tags = new HashSet<>();
+        tags.add(new Tag("a"));
+        c.setTags(tags);
+        CountryNoteEditCommand expected = new CountryNoteEditCommand(Index.fromOneBased(1), c);
 
-            CountryNoteEditCommand actual = parser.parse(" 1 nt/abc t/a");
-            assertEquals(expected, actual);
-        } catch (ParseException e) {
-            fail();
-        }
+        assertParseSuccess(parser, " 1 nt/abc t/a", expected);
     }
 
     @Test
     public void parse_noIndexWithNoteNoTag_throwsParseException() {
-        assertThrows(ParseException.class, () -> parser.parse(" nt/abc "));
-        assertThrows(ParseException.class, () -> parser.parse(" nt/y"));
-        assertThrows(ParseException.class, () -> parser.parse(" abc nt/y"));
-        assertThrows(ParseException.class, () -> parser.parse(" a 1 a nt/abc"));
+        assertParseFailure(parser, " nt/abc", invalidCommandError);
+        assertParseFailure(parser, " nt/y", invalidCommandError);
+        assertParseFailure(parser, " abc nt/abc", invalidIndexError);
+        assertParseFailure(parser, " a 1 a nt/abc", invalidIndexError);
     }
 
     @Test
     public void parse_withIndexNoNoteNoTag_throwsParseException() {
-        assertThrows(ParseException.class, () -> parser.parse(" 1 "));
-        assertThrows(ParseException.class, () -> parser.parse(" 1 t/"));
-        assertThrows(ParseException.class, () -> parser.parse(" 1 nt/"));
-        assertThrows(ParseException.class, () -> parser.parse(" 1 nt/ t/"));
+        assertParseFailure(parser, " 1  ", invalidCommandError);
+        assertParseFailure(parser, " 1 t/", invalidTagError);
+        assertParseFailure(parser, " 1 nt/", invalidNoteError);
+        assertParseFailure(parser, " 1 nt/ t/", invalidTagError);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/CountryNoteEditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CountryNoteEditCommandParserTest.java
@@ -20,7 +20,8 @@ public class CountryNoteEditCommandParserTest {
     private final TagNoteMap tagNoteMap = new TagNoteMap();
     private final CountryNoteEditCommandParser parser = new CountryNoteEditCommandParser(tagNoteMap);
     private final String invalidCommandError = "Invalid command format! \n"
-            + "country note edit: Edits the country note at the given index in the last viewed country note list panel.\n"
+            + "country note edit: "
+            + "Edits the country note at the given index in the last viewed country note list panel.\n"
             + "Parameters: INDEX (nt/NOTE_STRING ) (t/TAG)...\n"
             + "Example: country note edit 1 nt/better government stability in recent months";
     private final String invalidIndexError = "Index is not a non-zero unsigned integer.";

--- a/src/test/java/seedu/address/logic/parser/CountryNoteEditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CountryNoteEditCommandParserTest.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CountryNoteEditCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.country.Country;
+import seedu.address.model.note.CountryNote;
+import seedu.address.model.note.TagNoteMap;
+import seedu.address.model.tag.Tag;
+
+public class CountryNoteEditCommandParserTest {
+
+    private final TagNoteMap tagNoteMap = new TagNoteMap();
+    private final CountryNoteEditCommandParser parser = new CountryNoteEditCommandParser(tagNoteMap);
+
+    @Test
+    public void parse_WithIndexWithNoteWithTag_returnsExpected() {
+        try {
+            CountryNote c = new CountryNote("abc", Country.NULL_COUNTRY);
+            Set<Tag> tags = new HashSet<>();
+            tags.add(new Tag("a"));
+            c.setTags(tags);
+            CountryNoteEditCommand expected = new CountryNoteEditCommand(Index.fromOneBased(1), c);
+
+            CountryNoteEditCommand actual = parser.parse(" 1 nt/abc t/a");
+            assertEquals(expected, actual);
+        } catch (ParseException e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void parse_noIndexWithNoteNoTag_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(" nt/abc "));
+        assertThrows(ParseException.class, () -> parser.parse(" nt/y"));
+        assertThrows(ParseException.class, () -> parser.parse(" abc nt/y"));
+        assertThrows(ParseException.class, () -> parser.parse(" a 1 a nt/abc"));
+    }
+
+    @Test
+    public void parse_withIndexNoNoteNoTag_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(" 1 "));
+        assertThrows(ParseException.class, () -> parser.parse(" 1 t/"));
+        assertThrows(ParseException.class, () -> parser.parse(" 1 nt/"));
+        assertThrows(ParseException.class, () -> parser.parse(" 1 nt/ t/"));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/MainParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MainParserTest.java
@@ -34,6 +34,7 @@ import seedu.address.logic.commands.ClientViewCommand;
 import seedu.address.logic.commands.CountryFilterCommand;
 import seedu.address.logic.commands.CountryNoteAddCommand;
 import seedu.address.logic.commands.CountryNoteDeleteCommand;
+import seedu.address.logic.commands.CountryNoteEditCommand;
 import seedu.address.logic.commands.CountryNoteViewCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -175,6 +176,18 @@ public class MainParserTest {
 
         CountryNoteDeleteCommand command = (CountryNoteDeleteCommand) parser.parseCommand(commandString);
         assertEquals(new CountryNoteDeleteCommand(INDEX_FIRST_CLIENT), command);
+    }
+
+    @Test
+    public void parseCountryNoteCommands_countryNoteEdit() throws Exception {
+        final String countryString = "SG";
+        final String noteString = "is hot";
+        final String commandString = CountryNoteEditCommand.COMMAND_WORD + " " + INDEX_FIRST_CLIENT.getOneBased()
+                + " " + PREFIX_NOTE + noteString;
+        CountryNote expected = new CountryNote(noteString, Country.NULL_COUNTRY);
+        CountryNoteEditCommand command = (CountryNoteEditCommand) parser.parseCommand(commandString);
+        CountryNoteEditCommand expectedCmd = new CountryNoteEditCommand(INDEX_FIRST_CLIENT, expected);
+        assertEquals(expectedCmd, command);
     }
 
     @Test

--- a/src/test/java/seedu/address/model/country/CountryNotesManagerTest.java
+++ b/src/test/java/seedu/address/model/country/CountryNotesManagerTest.java
@@ -175,8 +175,8 @@ public class CountryNotesManagerTest {
     public void setCountryNote_notExistsOldCountryNote_throwsAssertError() {
         CountryNote oldCountryNote = new CountryNote("random", new Country("SG"));
         CountryNote newCountryNote = new CountryNote("random2", new Country("MY"));
-        assertThrows(AssertionError.class,
-                () -> countryNotesManager.setCountryNote(oldCountryNote, newCountryNote));
+        assertThrows(AssertionError.class, () ->
+                countryNotesManager.setCountryNote(oldCountryNote, newCountryNote));
     }
 
 }

--- a/src/test/java/seedu/address/model/country/CountryNotesManagerTest.java
+++ b/src/test/java/seedu/address/model/country/CountryNotesManagerTest.java
@@ -157,4 +157,26 @@ public class CountryNotesManagerTest {
         assertNotEquals(countryNotesManager.hashCode(), countryNotesManagerWithCountryNote.hashCode());
     }
 
+    @Test
+    public void setCountryNote_validOldAndNewCountryNote_replacesOldCountryNoteWithNewCountryNote() {
+        CountryNote oldCountryNote = new CountryNote("random", new Country("SG"));
+        CountryNote newCountryNote = new CountryNote("random2", new Country("MY"));
+
+        countryNotesManager.addCountryNote(oldCountryNote);
+        assertTrue(countryNotesManager.hasCountryNote(oldCountryNote));
+        assertFalse(countryNotesManager.hasCountryNote(newCountryNote));
+
+        countryNotesManager.setCountryNote(oldCountryNote, newCountryNote);
+        assertFalse(countryNotesManager.hasCountryNote(oldCountryNote));
+        assertTrue(countryNotesManager.hasCountryNote(newCountryNote));
+    }
+
+    @Test
+    public void setCountryNote_notExistsOldCountryNote_throwsAssertError() {
+        CountryNote oldCountryNote = new CountryNote("random", new Country("SG"));
+        CountryNote newCountryNote = new CountryNote("random2", new Country("MY"));
+        assertThrows(AssertionError.class,
+                () -> countryNotesManager.setCountryNote(oldCountryNote, newCountryNote));
+    }
+
 }

--- a/src/test/java/seedu/address/model/note/CountryNoteTest.java
+++ b/src/test/java/seedu/address/model/note/CountryNoteTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.TestUtil.basicEqualsTests;
 
-
 import java.util.HashSet;
 import java.util.Set;
 
@@ -74,7 +73,8 @@ public class CountryNoteTest {
         assertEquals(countryNote.hashCode(), new CountryNote(COUNTRY_NOTE_CONTENT, COUNTRY).hashCode());
 
         // different country -> different hashcode
-        assertNotEquals(countryNote.hashCode(), new CountryNote(COUNTRY_NOTE_CONTENT, new Country("AL")).hashCode());
+        assertNotEquals(countryNote.hashCode(),
+                new CountryNote(COUNTRY_NOTE_CONTENT, new Country("AL")).hashCode());
 
         // different note content -> different hashcode
         assertNotEquals(countryNote.hashCode(), new CountryNote("new country note", COUNTRY).hashCode());

--- a/src/test/java/seedu/address/model/note/CountryNoteTest.java
+++ b/src/test/java/seedu/address/model/note/CountryNoteTest.java
@@ -22,4 +22,19 @@ public class CountryNoteTest {
         assertEquals(country, countryNote.getCountry());
     }
 
+    @Test
+    public void constructor_countryNote_ensureIsEqual() {
+        CountryNote c = new CountryNote("random", new Country("MY"));
+        CountryNote copy = new CountryNote(c);
+        assertEquals(copy, c);
+    }
+
+    @Test
+    public void setCountry_returnsExpected() {
+        CountryNote c = new CountryNote("random", new Country("MY"));
+        CountryNote actual = c.setCountry(new Country("SG"));
+        CountryNote expected = new CountryNote("random", new Country("SG"));
+        assertEquals(expected, actual);
+    }
+
 }

--- a/src/test/java/seedu/address/model/note/CountryNoteTest.java
+++ b/src/test/java/seedu/address/model/note/CountryNoteTest.java
@@ -3,9 +3,13 @@ package seedu.address.model.note;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.junit.jupiter.api.Test;
 
 import seedu.address.model.country.Country;
+import seedu.address.model.tag.Tag;
 
 public class CountryNoteTest {
 
@@ -23,18 +27,15 @@ public class CountryNoteTest {
     }
 
     @Test
-    public void constructor_countryNote_ensureIsEqual() {
-        CountryNote c = new CountryNote("random", new Country("MY"));
-        CountryNote copy = new CountryNote(c);
-        assertEquals(copy, c);
-    }
-
-    @Test
-    public void setCountry_returnsExpected() {
-        CountryNote c = new CountryNote("random", new Country("MY"));
-        CountryNote actual = c.setCountry(new Country("SG"));
-        CountryNote expected = new CountryNote("random", new Country("SG"));
-        assertEquals(expected, actual);
+    public void constructor_countryNote_ensureEqualsExpected() {
+        String content = "content";
+        Country country = new Country("SG");
+        Set<Tag> tags = new HashSet<>();
+        tags.add(new Tag("t"));
+        CountryNote c = new CountryNote(content, country, tags);
+        assertEquals(content, c.getNoteContent());
+        assertEquals(country, c.getCountry());
+        assertEquals(tags, c.getTags());
     }
 
 }


### PR DESCRIPTION
## Description

command syntax: `country note edit INDEX (nt/NOTE_STRING) (t/TAG)...`

Fixes #262 

## Testing

Not much since this feature was expedited. Mainly tests for `CountryNoteEditCommandParser`.

## Remarks

NIL.
