### PR TITLE
Fix Ordering Bug for ClientNoteEdit

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClientEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientEditCommand.java
@@ -107,7 +107,7 @@ public class ClientEditCommand extends Command {
         ContractExpiryDate updatedContractExpiryDate =
                 editClientDescriptor.getContractExpiryDate().orElse(clientToEdit.getContractExpiryDate());
         LastModifiedInstant updatedLastModifiedInstant = new LastModifiedInstant();
-        ArrayList<Note> retainedClientNotes = new ArrayList<>(clientToEdit.getClientNotes());
+        ArrayList<Note> retainedClientNotes = new ArrayList<>(clientToEdit.getClientNotesAsUnmodifiableList());
         Client newClient = new Client(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedCountry,
                 updatedTimezone, updatedContractExpiryDate, updatedLastModifiedInstant);
         retainedClientNotes.forEach(clientNote -> newClient.addClientNote(clientNote));

--- a/src/main/java/seedu/address/logic/commands/ClientEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientEditCommand.java
@@ -9,7 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIMEZONE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_CLIENTS;
 
-import java.util.LinkedHashSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -107,7 +107,7 @@ public class ClientEditCommand extends Command {
         ContractExpiryDate updatedContractExpiryDate =
                 editClientDescriptor.getContractExpiryDate().orElse(clientToEdit.getContractExpiryDate());
         LastModifiedInstant updatedLastModifiedInstant = new LastModifiedInstant();
-        LinkedHashSet<Note> retainedClientNotes = new LinkedHashSet<>(clientToEdit.getClientNotes());
+        ArrayList<Note> retainedClientNotes = new ArrayList<>(clientToEdit.getClientNotes());
         Client newClient = new Client(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedCountry,
                 updatedTimezone, updatedContractExpiryDate, updatedLastModifiedInstant);
         retainedClientNotes.forEach(clientNote -> newClient.addClientNote(clientNote));

--- a/src/main/java/seedu/address/logic/commands/ClientNoteDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientNoteDeleteCommand.java
@@ -48,12 +48,12 @@ public class ClientNoteDeleteCommand extends Command {
         if (targetClientIndex.getZeroBased() >= lastShownClientList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
         }
-        List<Note> notesList = lastShownClientList.get(targetClientIndex.getZeroBased()).getClientNotesAsList();
+        List<Note> notesList = lastShownClientList.get(targetClientIndex.getZeroBased()).getClientNotes();
         if (targetClientNoteIndex.getZeroBased() >= notesList.size()) {
             throw new CommandException(MESSAGE_INVALID_CLIENT_NOTE_DISPLAYED_INDEX);
         }
         Client associatedClient = lastShownClientList.get(targetClientIndex.getZeroBased());
-        Note noteToDelete = associatedClient.getClientNotesAsList().get(targetClientNoteIndex.getZeroBased());
+        Note noteToDelete = associatedClient.getClientNotes().get(targetClientNoteIndex.getZeroBased());
         assert associatedClient.hasClientNote(noteToDelete) : "attempting to delete client note that doesn't exist";
         model.deleteClientNote(associatedClient, noteToDelete);
         return new CommandResult(MESSAGE_DELETED_CLIENT_NOTE_SUCCESS);

--- a/src/main/java/seedu/address/logic/commands/ClientNoteDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientNoteDeleteCommand.java
@@ -48,12 +48,14 @@ public class ClientNoteDeleteCommand extends Command {
         if (targetClientIndex.getZeroBased() >= lastShownClientList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
         }
-        List<Note> notesList = lastShownClientList.get(targetClientIndex.getZeroBased()).getClientNotesAsList();
+        List<Note> notesList = lastShownClientList.get(targetClientIndex.getZeroBased())
+                .getClientNotesAsUnmodifiableList();
         if (targetClientNoteIndex.getZeroBased() >= notesList.size()) {
             throw new CommandException(MESSAGE_INVALID_CLIENT_NOTE_DISPLAYED_INDEX);
         }
         Client associatedClient = lastShownClientList.get(targetClientIndex.getZeroBased());
-        Note noteToDelete = associatedClient.getClientNotesAsList().get(targetClientNoteIndex.getZeroBased());
+        Note noteToDelete = associatedClient.getClientNotesAsUnmodifiableList()
+                .get(targetClientNoteIndex.getZeroBased());
         assert associatedClient.hasClientNote(noteToDelete) : "attempting to delete client note that doesn't exist";
         model.deleteClientNote(associatedClient, noteToDelete);
         return new CommandResult(MESSAGE_DELETED_CLIENT_NOTE_SUCCESS);

--- a/src/main/java/seedu/address/logic/commands/ClientNoteDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientNoteDeleteCommand.java
@@ -76,6 +76,5 @@ public class ClientNoteDeleteCommand extends Command {
 
         return this.targetClientIndex.equals(c.targetClientIndex)
                 && this.targetClientNoteIndex.equals(c.targetClientNoteIndex);
-        // todo: question: is it better to check commmand equality using the ClientNote object or it's associated index?
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ClientNoteDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientNoteDeleteCommand.java
@@ -48,12 +48,12 @@ public class ClientNoteDeleteCommand extends Command {
         if (targetClientIndex.getZeroBased() >= lastShownClientList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
         }
-        List<Note> notesList = lastShownClientList.get(targetClientIndex.getZeroBased()).getClientNotes();
+        List<Note> notesList = lastShownClientList.get(targetClientIndex.getZeroBased()).getClientNotesAsList();
         if (targetClientNoteIndex.getZeroBased() >= notesList.size()) {
             throw new CommandException(MESSAGE_INVALID_CLIENT_NOTE_DISPLAYED_INDEX);
         }
         Client associatedClient = lastShownClientList.get(targetClientIndex.getZeroBased());
-        Note noteToDelete = associatedClient.getClientNotes().get(targetClientNoteIndex.getZeroBased());
+        Note noteToDelete = associatedClient.getClientNotesAsList().get(targetClientNoteIndex.getZeroBased());
         assert associatedClient.hasClientNote(noteToDelete) : "attempting to delete client note that doesn't exist";
         model.deleteClientNote(associatedClient, noteToDelete);
         return new CommandResult(MESSAGE_DELETED_CLIENT_NOTE_SUCCESS);

--- a/src/main/java/seedu/address/logic/commands/ClientNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientNoteEditCommand.java
@@ -55,12 +55,12 @@ public class ClientNoteEditCommand extends Command {
         if (targetClientIndex.getZeroBased() >= lastShownClientList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
         }
-        List<Note> notesList = lastShownClientList.get(targetClientIndex.getZeroBased()).getClientNotesAsList();
+        List<Note> notesList = lastShownClientList.get(targetClientIndex.getZeroBased()).getClientNotes();
         if (targetClientNoteIndex.getZeroBased() >= notesList.size()) {
             throw new CommandException(MESSAGE_INVALID_CLIENT_NOTE_DISPLAYED_INDEX);
         }
         Client associatedClient = lastShownClientList.get(targetClientIndex.getZeroBased());
-        Note noteToEdit = associatedClient.getClientNotesAsList().get(targetClientNoteIndex.getZeroBased());
+        Note noteToEdit = associatedClient.getClientNotes().get(targetClientNoteIndex.getZeroBased());
         assert associatedClient.hasClientNote(noteToEdit) : "attempting to edit client note that doesn't exist";
         Set<Tag> accumulatedTags = new HashSet<>();
         accumulatedTags.addAll(noteToEdit.getTags()); // these are the previous tags, because we want to retain history

--- a/src/main/java/seedu/address/logic/commands/ClientNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientNoteEditCommand.java
@@ -28,7 +28,8 @@ public class ClientNoteEditCommand extends Command {
             + "and the index number for client note in the displayed client notes list.\n"
             + "Parameters: CLIENT_INDEX CLIENT_NOTE_INDEX " + PREFIX_NOTE + "NOTE_STRING [" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 1 " + PREFIX_NOTE + "client note newly edited content";
-    public static final String MESSAGE_EDIT_CLIENT_NOTE_SUCCESS = "Successfully edited client note";
+    public static final String MESSAGE_EDIT_CLIENT_NOTE_SUCCESS = "Successfully edited note for %1$s: \n Before: "
+            + "%2$s\n After: %3$s";
     private static final String MESSAGE_INVALID_CLIENT_NOTE_DISPLAYED_INDEX = "The client note index provided is "
             + "invalid";
     private final Index targetClientIndex;
@@ -73,7 +74,8 @@ public class ClientNoteEditCommand extends Command {
         }
         newNote.setTags(accumulatedTags);
         model.editClientNote(associatedClient, noteToEdit, newNote);
-        return new CommandResult(MESSAGE_EDIT_CLIENT_NOTE_SUCCESS);
+        return new CommandResult(String.format(MESSAGE_EDIT_CLIENT_NOTE_SUCCESS, associatedClient.getName(), noteToEdit,
+                newNote));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ClientNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientNoteEditCommand.java
@@ -55,12 +55,12 @@ public class ClientNoteEditCommand extends Command {
         if (targetClientIndex.getZeroBased() >= lastShownClientList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
         }
-        List<Note> notesList = lastShownClientList.get(targetClientIndex.getZeroBased()).getClientNotes();
+        List<Note> notesList = lastShownClientList.get(targetClientIndex.getZeroBased()).getClientNotesAsList();
         if (targetClientNoteIndex.getZeroBased() >= notesList.size()) {
             throw new CommandException(MESSAGE_INVALID_CLIENT_NOTE_DISPLAYED_INDEX);
         }
         Client associatedClient = lastShownClientList.get(targetClientIndex.getZeroBased());
-        Note noteToEdit = associatedClient.getClientNotes().get(targetClientNoteIndex.getZeroBased());
+        Note noteToEdit = associatedClient.getClientNotesAsList().get(targetClientNoteIndex.getZeroBased());
         assert associatedClient.hasClientNote(noteToEdit) : "attempting to edit client note that doesn't exist";
         Set<Tag> accumulatedTags = new HashSet<>();
         accumulatedTags.addAll(noteToEdit.getTags()); // these are the previous tags, because we want to retain history

--- a/src/main/java/seedu/address/logic/commands/ClientNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientNoteEditCommand.java
@@ -55,12 +55,13 @@ public class ClientNoteEditCommand extends Command {
         if (targetClientIndex.getZeroBased() >= lastShownClientList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX);
         }
-        List<Note> notesList = lastShownClientList.get(targetClientIndex.getZeroBased()).getClientNotesAsList();
+        List<Note> notesList = lastShownClientList.get(targetClientIndex.getZeroBased())
+                .getClientNotesAsUnmodifiableList();
         if (targetClientNoteIndex.getZeroBased() >= notesList.size()) {
             throw new CommandException(MESSAGE_INVALID_CLIENT_NOTE_DISPLAYED_INDEX);
         }
         Client associatedClient = lastShownClientList.get(targetClientIndex.getZeroBased());
-        Note noteToEdit = associatedClient.getClientNotesAsList().get(targetClientNoteIndex.getZeroBased());
+        Note noteToEdit = associatedClient.getClientNotesAsUnmodifiableList().get(targetClientNoteIndex.getZeroBased());
         assert associatedClient.hasClientNote(noteToEdit) : "attempting to edit client note that doesn't exist";
         Set<Tag> accumulatedTags = new HashSet<>();
         accumulatedTags.addAll(noteToEdit.getTags()); // these are the previous tags, because we want to retain history

--- a/src/main/java/seedu/address/logic/commands/ClientNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientNoteEditCommand.java
@@ -63,7 +63,8 @@ public class ClientNoteEditCommand extends Command {
         }
         Client associatedClient = lastShownClientList.get(targetClientIndex.getZeroBased());
         Note noteToEdit = associatedClient.getClientNotesAsUnmodifiableList().get(targetClientNoteIndex.getZeroBased());
-        assert associatedClient.hasClientNote(noteToEdit) : "attempting to edit client note that doesn't exist";
+        assert associatedClient.hasClientNote(noteToEdit) : "attempting to edit client"
+                + " note that doesn't exist";
         Set<Tag> accumulatedTags = new HashSet<>();
         accumulatedTags.addAll(noteToEdit.getTags()); // these are the previous tags, because we want to retain history
         accumulatedTags.addAll(newNote.getTags());

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -6,7 +6,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -140,7 +139,7 @@ public class ModelManager implements Model {
     public void addClient(Client client) {
         tbmManager.addClient(client);
         updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
-        LinkedHashSet<Note> clientNotes = new LinkedHashSet<>(client.getClientNotes());
+        List<Note> clientNotes = new ArrayList<>(client.getClientNotes());
         for (Note note : clientNotes) {
             Set<Tag> tags = note.getTags();
             updateTagNoteMapWithNote(tags, note);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -140,7 +141,7 @@ public class ModelManager implements Model {
     public void addClient(Client client) {
         tbmManager.addClient(client);
         updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
-        Set<Note> clientNotes = client.getClientNotes();
+        LinkedHashSet<Note> clientNotes = new LinkedHashSet<>(client.getClientNotes());
         for (Note note : clientNotes) {
             Set<Tag> tags = note.getTags();
             updateTagNoteMapWithNote(tags, note);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -6,7 +6,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -210,7 +209,7 @@ public class ModelManager implements Model {
     public void initialiseTagNoteMap() {
         this.tagNoteMap.initTagNoteMapFromClients(this.tbmManager.getClientList());
         // todo: initialiseTagNoteMap probably has to be changed to use TbmManager#getNoteList()
-        this.tagNoteMap.initTagNoteMapFromCountryNotes(new HashSet<>(this.tbmManager.getCountryNoteList()));
+        this.tagNoteMap.initTagNoteMapFromCountryNotes(new ArrayList<>(this.tbmManager.getCountryNoteList()));
     }
 
     public TagNoteMap getTagNoteMap() {

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -139,7 +139,7 @@ public class ModelManager implements Model {
     public void addClient(Client client) {
         tbmManager.addClient(client);
         updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
-        List<Note> clientNotes = new ArrayList<>(client.getClientNotes());
+        List<Note> clientNotes = new ArrayList<>(client.getClientNotesAsUnmodifiableList());
         for (Note note : clientNotes) {
             Set<Tag> tags = note.getTags();
             updateTagNoteMapWithNote(tags, note);
@@ -241,7 +241,7 @@ public class ModelManager implements Model {
         // todo: depends on UI display of client notes and their index
         List<Note> clientNotes = new ArrayList<>();
         for (Client client : getSortedFilteredClientList()) {
-            clientNotes.addAll(client.getClientNotes());
+            clientNotes.addAll(client.getClientNotesAsUnmodifiableList());
         }
         return FXCollections.observableList(clientNotes);
     }

--- a/src/main/java/seedu/address/model/TbmManager.java
+++ b/src/main/java/seedu/address/model/TbmManager.java
@@ -182,7 +182,7 @@ public class TbmManager implements ReadOnlyTbmManager {
     @Override
     public ObservableList<Note> getNoteList() {
         ArrayList<Note> accumulated = new ArrayList<>(getCountryNoteList());
-        this.clients.forEach(client -> accumulated.addAll(client.getClientNotes()));
+        this.clients.forEach(client -> accumulated.addAll(client.getClientNotesAsUnmodifiableList()));
         return FXCollections.observableArrayList(accumulated);
     }
 

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -98,8 +98,15 @@ public class Client {
         return Collections.unmodifiableList(new ArrayList<>(getClientNotes()));
     }
 
+    /**
+     * Exposes the note list as an ObservableList of notes for {@code WidgetViewBox}.
+     * For purpose of adding a listener to the underlying note list of the client, this returns the list itself
+     * as a singleton object.
+     *
+     * @return ObservableList of Notes
+     */
     public ObservableList<Note> getClientNotesAsObservableList() {
-        return FXCollections.observableArrayList(clientNotes);
+        return clientNotes;
     }
     /**
      * Adds a client note for this client.

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -29,7 +29,6 @@ public class Client {
     private final Country country;
     private final Timezone timezone;
     private final ContractExpiryDate contractExpiryDate;
-    // private final LinkedHashSet<Note> clientNotes =new LinkedHashSet<>(); // this change will break the GUI updating
     private final ObservableList<Note> clientNotes = FXCollections.observableArrayList(new ArrayList<>());
     private final LastModifiedInstant lastModifiedInstant;
 
@@ -99,9 +98,8 @@ public class Client {
         return Collections.unmodifiableList(new ArrayList<>(getClientNotes()));
     }
 
-    public ObservableList<Note> getClientNotesAsObservableSet() {
+    public ObservableList<Note> getClientNotesAsObservableList() {
         return FXCollections.observableArrayList(clientNotes);
-        // return clientNotes;
     }
     /**
      * Adds a client note for this client.
@@ -134,8 +132,6 @@ public class Client {
         int targetIdx = clientNotes.indexOf(clientNote);
         clientNotes.set(targetIdx, newNote);
         assert(!clientNotes.contains(clientNote));
-        //        this.clientNotes.remove(clientNote);
-        //        this.clientNotes.add(newNote);
     }
 
     /**

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -122,7 +122,7 @@ public class Client {
         requireNonNull(clientNote);
         int targetIdx = clientNotes.indexOf(clientNote);
         clientNotes.set(targetIdx, newNote);
-        assert(!clientNotes.contains(clientNote));
+        assert !clientNotes.contains(clientNote);
     }
 
     /**

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -5,13 +5,11 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 
 import javafx.collections.FXCollections;
-import javafx.collections.ObservableSet;
+import javafx.collections.ObservableList;
 import seedu.address.model.country.Country;
 import seedu.address.model.note.Note;
 
@@ -32,7 +30,7 @@ public class Client {
     private final Timezone timezone;
     private final ContractExpiryDate contractExpiryDate;
     // private final LinkedHashSet<Note> clientNotes =new LinkedHashSet<>(); // this change will break the GUI updating
-    private final ObservableSet<Note> clientNotes = FXCollections.observableSet(new LinkedHashSet<>());
+    private final ObservableList<Note> clientNotes = FXCollections.observableArrayList(new ArrayList<>());
     private final LastModifiedInstant lastModifiedInstant;
 
     /**
@@ -88,8 +86,8 @@ public class Client {
      *
      * @return The list of client notes associated with this client.
      */
-    public Set<Note> getClientNotes() {
-        return Collections.unmodifiableSet(this.clientNotes);
+    public List<Note> getClientNotes() {
+        return Collections.unmodifiableList(this.clientNotes);
     }
 
     /**
@@ -101,8 +99,8 @@ public class Client {
         return Collections.unmodifiableList(new ArrayList<>(getClientNotes()));
     }
 
-    public ObservableSet<Note> getClientNotesAsObservableSet() {
-        return FXCollections.observableSet(clientNotes);
+    public ObservableList<Note> getClientNotesAsObservableSet() {
+        return FXCollections.observableArrayList(clientNotes);
         // return clientNotes;
     }
     /**

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -89,15 +89,6 @@ public class Client {
         return Collections.unmodifiableList(this.clientNotes);
     }
 
-    /**
-     * Gets the list of client notes associated with this client as an unmodifiable list.
-     *
-     * @return An unmodifiable list of client notes associated with this client.
-     */
-    public List<Note> getClientNotesAsList() {
-        return Collections.unmodifiableList(new ArrayList<>(getClientNotes()));
-    }
-
     public ObservableList<Note> getClientNotesAsObservableList() {
         return FXCollections.observableArrayList(clientNotes);
     }

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -99,7 +99,7 @@ public class Client {
     }
 
     public ObservableList<Note> getClientNotesAsObservableList() {
-        return FXCollections.observableArrayList(clientNotes);
+        return clientNotes;
     }
     /**
      * Adds a client note for this client.

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -89,6 +89,15 @@ public class Client {
         return Collections.unmodifiableList(this.clientNotes);
     }
 
+    /**
+     * Gets the list of client notes associated with this client as an unmodifiable list.
+     *
+     * @return An unmodifiable list of client notes associated with this client.
+     */
+    public List<Note> getClientNotesAsList() {
+        return Collections.unmodifiableList(new ArrayList<>(getClientNotes()));
+    }
+
     public ObservableList<Note> getClientNotesAsObservableList() {
         return FXCollections.observableArrayList(clientNotes);
     }

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -85,17 +85,8 @@ public class Client {
      *
      * @return The list of client notes associated with this client.
      */
-    public List<Note> getClientNotes() {
+    public List<Note> getClientNotesAsUnmodifiableList() {
         return Collections.unmodifiableList(this.clientNotes);
-    }
-
-    /**
-     * Gets the list of client notes associated with this client as an unmodifiable list.
-     *
-     * @return An unmodifiable list of client notes associated with this client.
-     */
-    public List<Note> getClientNotesAsList() {
-        return Collections.unmodifiableList(new ArrayList<>(getClientNotes()));
     }
 
     public ObservableList<Note> getClientNotesAsObservableList() {

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -80,7 +80,6 @@ public class Client {
         return lastModifiedInstant;
     }
 
-
     /**
      * Gets the list of client notes associated with this client.
      *
@@ -90,15 +89,8 @@ public class Client {
         return Collections.unmodifiableList(this.clientNotes);
     }
 
-    /**
-     * Exposes the note list as an ObservableList of notes for {@code WidgetViewBox}.
-     * For purpose of adding a listener to the underlying note list of the client, this returns the list itself
-     * as a singleton object.
-     *
-     * @return ObservableList of Notes
-     */
     public ObservableList<Note> getClientNotesAsObservableList() {
-        return clientNotes;
+        return FXCollections.observableArrayList(clientNotes);
     }
     /**
      * Adds a client note for this client.

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -131,8 +131,11 @@ public class Client {
      */
     public void editClientNote(Note clientNote, Note newNote) {
         requireNonNull(clientNote);
-        this.clientNotes.remove(clientNote);
-        this.clientNotes.add(newNote);
+        int targetIdx = clientNotes.indexOf(clientNote);
+        clientNotes.set(targetIdx, newNote);
+        assert(!clientNotes.contains(clientNote));
+        //        this.clientNotes.remove(clientNote);
+        //        this.clientNotes.add(newNote);
     }
 
     /**

--- a/src/main/java/seedu/address/model/client/Client.java
+++ b/src/main/java/seedu/address/model/client/Client.java
@@ -31,6 +31,7 @@ public class Client {
     private final Country country;
     private final Timezone timezone;
     private final ContractExpiryDate contractExpiryDate;
+    // private final LinkedHashSet<Note> clientNotes =new LinkedHashSet<>(); // this change will break the GUI updating
     private final ObservableSet<Note> clientNotes = FXCollections.observableSet(new LinkedHashSet<>());
     private final LastModifiedInstant lastModifiedInstant;
 
@@ -101,7 +102,8 @@ public class Client {
     }
 
     public ObservableSet<Note> getClientNotesAsObservableSet() {
-        return clientNotes;
+        return FXCollections.observableSet(clientNotes);
+        // return clientNotes;
     }
     /**
      * Adds a client note for this client.
@@ -133,7 +135,6 @@ public class Client {
         requireNonNull(clientNote);
         this.clientNotes.remove(clientNote);
         this.clientNotes.add(newNote);
-        // todo: keep existing tags.
     }
 
     /**

--- a/src/main/java/seedu/address/model/client/UniqueClientList.java
+++ b/src/main/java/seedu/address/model/client/UniqueClientList.java
@@ -27,7 +27,7 @@ public class UniqueClientList implements Iterable<Client> {
 
     // Initialize observableArrayList with a Callback that monitors change in the clients' notes list
     private final ObservableList<Client> internalList = FXCollections.observableArrayList(client ->
-            new Observable[] { client.getClientNotesAsObservableSet() });
+            new Observable[] { client.getClientNotesAsObservableList() });
     private final ObservableList<Client> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);
 

--- a/src/main/java/seedu/address/model/note/TagNoteMap.java
+++ b/src/main/java/seedu/address/model/note/TagNoteMap.java
@@ -39,6 +39,7 @@ public class TagNoteMap {
      */
     public TagNoteMap() {
         uniqueTagMap.put(Tag.UNTAGGED, Tag.UNTAGGED);
+        tagToNotesMap.put(Tag.UNTAGGED, new ArrayList<>());
     }
 
     private void initTagNoteMapFromNotes(List<Note> notes) {
@@ -122,7 +123,8 @@ public class TagNoteMap {
         for (Tag tag : associatedTags) { // remove note for relevant tags
             List<Note> notes = this.tagToNotesMap.get(tag);
             notes.remove(note);
-            if (notes.isEmpty()) { // remove the tag itself from tagToNotesMap and uniqueTagMap:
+            if (notes.isEmpty() && !tag.equals(Tag.UNTAGGED)) {
+                // other than default Tag.UNTAGGED, remove the tag itself from tagToNotesMap and uniqueTagMap:
                 this.tagToNotesMap.remove(tag);
                 this.uniqueTagMap.remove(tag);
             }
@@ -142,17 +144,20 @@ public class TagNoteMap {
         assert noteToTagsMap.containsKey(noteToEdit) : "trying to remove note that doesn't exist in noteToTagsMap";
         noteSet.remove(noteToEdit);
         Set<Tag> associatedTags = this.noteToTagsMap.get(noteToEdit);
-        for (Tag tag : associatedTags) { // remove note for relevant tags
+        // remove this note's association for relevant tags:
+        for (Tag tag : associatedTags) {
             List<Note> notes = this.tagToNotesMap.get(tag);
-            notes.remove(noteToEdit); // todo: this could be affecting the order of notes eventually, should to a put?
-            if (notes.isEmpty()) { // remove the tag itself from tagToNotesMap and uniqueTagMap:
+            notes.remove(noteToEdit);
+            // remove the tag from tagToNotesMap and uniqueTagMap if that tag has no associated notes left and is not
+            // default tag of Tag.UNTAGGED:
+            if (notes.isEmpty() && !tag.equals(Tag.UNTAGGED)) {
                 this.tagToNotesMap.remove(tag);
                 this.uniqueTagMap.remove(tag);
             }
         }
         noteSet.add(newNote);
         noteToTagsMap.remove(noteToEdit);
-        addTagsForNote(newNote.getTags(), newNote); // todo: change this to retain past tags
+        addTagsForNote(newNote.getTags(), newNote);
     }
 
     /**
@@ -170,6 +175,8 @@ public class TagNoteMap {
             if (tagToNotesMap.containsKey(newTag)) { // if that tag exists
                 tagToNotesMap.get(newTag).add(note);
             } else { // new tag:
+                // todo: have to put into uniqueTagSet!!!
+                this.uniqueTagMap.put(newTag, newTag);
                 List<Note> notes = new ArrayList<>();
                 notes.add(note);
                 tagToNotesMap.put(newTag, notes);

--- a/src/main/java/seedu/address/model/note/TagNoteMap.java
+++ b/src/main/java/seedu/address/model/note/TagNoteMap.java
@@ -148,8 +148,7 @@ public class TagNoteMap {
         for (Tag tag : associatedTags) {
             List<Note> notes = this.tagToNotesMap.get(tag);
             notes.remove(noteToEdit);
-            // remove the tag from tagToNotesMap and uniqueTagMap if that tag has no associated notes left and is not
-            // default tag of Tag.UNTAGGED:
+            // other than default Tag.UNTAGGED, remove the tag itself from tagToNotesMap and uniqueTagMap:
             if (notes.isEmpty() && !tag.equals(Tag.UNTAGGED)) {
                 this.tagToNotesMap.remove(tag);
                 this.uniqueTagMap.remove(tag);
@@ -175,7 +174,6 @@ public class TagNoteMap {
             if (tagToNotesMap.containsKey(newTag)) { // if that tag exists
                 tagToNotesMap.get(newTag).add(note);
             } else { // new tag:
-                // todo: have to put into uniqueTagSet!!!
                 this.uniqueTagMap.put(newTag, newTag);
                 List<Note> notes = new ArrayList<>();
                 notes.add(note);

--- a/src/main/java/seedu/address/model/note/TagNoteMap.java
+++ b/src/main/java/seedu/address/model/note/TagNoteMap.java
@@ -61,7 +61,7 @@ public class TagNoteMap {
     public void initTagNoteMapFromClients(List<Client> clients) {
         requireAllNonNull(clients);
         for (Client client : clients) {
-            List<Note> clientNotes = client.getClientNotes();
+            List<Note> clientNotes = client.getClientNotesAsUnmodifiableList();
             initTagNoteMapFromNotes(clientNotes);
         }
         logger.info("--------------[TagNoteMap initialized from clients]");

--- a/src/main/java/seedu/address/model/note/TagNoteMap.java
+++ b/src/main/java/seedu/address/model/note/TagNoteMap.java
@@ -2,6 +2,7 @@ package seedu.address.model.note;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,7 +31,7 @@ public class TagNoteMap {
      */
     private final Map<Tag, Tag> uniqueTagMap = new HashMap<>();
     private final LinkedHashSet<Note> noteSet = new LinkedHashSet<>(); // TODO: not really needed
-    private final Map<Tag, LinkedHashSet<Note>> tagToNotesMap = new HashMap<>();
+    private final Map<Tag, List<Note>> tagToNotesMap = new HashMap<>();
     private final Map<Note, LinkedHashSet<Tag>> noteToTagsMap = new HashMap<>(); // TODO: not really needed
 
     /**
@@ -40,7 +41,7 @@ public class TagNoteMap {
         uniqueTagMap.put(Tag.UNTAGGED, Tag.UNTAGGED);
     }
 
-    private void initTagNoteMapFromNotes(Set<Note> notes) {
+    private void initTagNoteMapFromNotes(List<Note> notes) {
         noteSet.addAll(notes);
         for (Note clientNote : notes) {
             Set<Tag> tags = clientNote.getTags();
@@ -59,7 +60,7 @@ public class TagNoteMap {
     public void initTagNoteMapFromClients(List<Client> clients) {
         requireAllNonNull(clients);
         for (Client client : clients) {
-            Set<Note> clientNotes = client.getClientNotes();
+            List<Note> clientNotes = client.getClientNotes();
             initTagNoteMapFromNotes(clientNotes);
         }
         logger.info("--------------[TagNoteMap initialized from clients]");
@@ -70,7 +71,7 @@ public class TagNoteMap {
      *
      * @param countryNotes The set of countries, each containing their notes and associated tags.
      */
-    public void initTagNoteMapFromCountryNotes(Set<Note> countryNotes) {
+    public void initTagNoteMapFromCountryNotes(List<Note> countryNotes) {
         // todo: make init work when passed in a list of countryNotes
         requireAllNonNull(countryNotes);
         initTagNoteMapFromNotes(countryNotes);
@@ -103,8 +104,8 @@ public class TagNoteMap {
         return Collections.unmodifiableSet(noteToTagsMap.getOrDefault(note, new LinkedHashSet<>()));
     }
 
-    public Set<Note> getNotesForTag(Tag tag) {
-        return Collections.unmodifiableSet(tagToNotesMap.getOrDefault(tag, new LinkedHashSet<>()));
+    public List<Note> getNotesForTag(Tag tag) {
+        return Collections.unmodifiableList(tagToNotesMap.getOrDefault(tag, new ArrayList<>()));
     }
 
     /**
@@ -119,7 +120,7 @@ public class TagNoteMap {
         noteSet.remove(note);
         Set<Tag> associatedTags = this.noteToTagsMap.get(note);
         for (Tag tag : associatedTags) { // remove note for relevant tags
-            Set<Note> notes = this.tagToNotesMap.get(tag);
+            List<Note> notes = this.tagToNotesMap.get(tag);
             notes.remove(note);
             if (notes.isEmpty()) { // remove the tag itself from tagToNotesMap and uniqueTagMap:
                 this.tagToNotesMap.remove(tag);
@@ -142,7 +143,7 @@ public class TagNoteMap {
         noteSet.remove(noteToEdit);
         Set<Tag> associatedTags = this.noteToTagsMap.get(noteToEdit);
         for (Tag tag : associatedTags) { // remove note for relevant tags
-            LinkedHashSet<Note> notes = this.tagToNotesMap.get(tag);
+            List<Note> notes = this.tagToNotesMap.get(tag);
             notes.remove(noteToEdit); // todo: this could be affecting the order of notes eventually, should to a put?
             if (notes.isEmpty()) { // remove the tag itself from tagToNotesMap and uniqueTagMap:
                 this.tagToNotesMap.remove(tag);
@@ -169,7 +170,7 @@ public class TagNoteMap {
             if (tagToNotesMap.containsKey(newTag)) { // if that tag exists
                 tagToNotesMap.get(newTag).add(note);
             } else { // new tag:
-                LinkedHashSet<Note> notes = new LinkedHashSet<>();
+                List<Note> notes = new ArrayList<>();
                 notes.add(note);
                 tagToNotesMap.put(newTag, notes);
             }

--- a/src/main/java/seedu/address/model/note/TagNoteMap.java
+++ b/src/main/java/seedu/address/model/note/TagNoteMap.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -28,9 +29,9 @@ public class TagNoteMap {
      * A map is used instead of a set because the set does not offer the option of getting objects inside it.
      */
     private final Map<Tag, Tag> uniqueTagMap = new HashMap<>();
-    private final Set<Note> noteSet = new HashSet<>(); // TODO: not really needed
-    private final Map<Tag, Set<Note>> tagToNotesMap = new HashMap<>();
-    private final Map<Note, Set<Tag>> noteToTagsMap = new HashMap<>(); // TODO: not really needed
+    private final LinkedHashSet<Note> noteSet = new LinkedHashSet<>(); // TODO: not really needed
+    private final Map<Tag, LinkedHashSet<Note>> tagToNotesMap = new HashMap<>();
+    private final Map<Note, LinkedHashSet<Tag>> noteToTagsMap = new HashMap<>(); // TODO: not really needed
 
     /**
      * Constructor ensures our unique tag map has the UNTAGGED tag.
@@ -99,11 +100,11 @@ public class TagNoteMap {
     }
 
     public Set<Tag> getTagsForNote(Note note) {
-        return Collections.unmodifiableSet(noteToTagsMap.getOrDefault(note, new HashSet<>()));
+        return Collections.unmodifiableSet(noteToTagsMap.getOrDefault(note, new LinkedHashSet<>()));
     }
 
     public Set<Note> getNotesForTag(Tag tag) {
-        return Collections.unmodifiableSet(tagToNotesMap.getOrDefault(tag, new HashSet<>()));
+        return Collections.unmodifiableSet(tagToNotesMap.getOrDefault(tag, new LinkedHashSet<>()));
     }
 
     /**
@@ -141,8 +142,8 @@ public class TagNoteMap {
         noteSet.remove(noteToEdit);
         Set<Tag> associatedTags = this.noteToTagsMap.get(noteToEdit);
         for (Tag tag : associatedTags) { // remove note for relevant tags
-            Set<Note> notes = this.tagToNotesMap.get(tag);
-            notes.remove(noteToEdit);
+            LinkedHashSet<Note> notes = this.tagToNotesMap.get(tag);
+            notes.remove(noteToEdit); // todo: this could be affecting the order of notes eventually, should to a put?
             if (notes.isEmpty()) { // remove the tag itself from tagToNotesMap and uniqueTagMap:
                 this.tagToNotesMap.remove(tag);
                 this.uniqueTagMap.remove(tag);
@@ -168,13 +169,13 @@ public class TagNoteMap {
             if (tagToNotesMap.containsKey(newTag)) { // if that tag exists
                 tagToNotesMap.get(newTag).add(note);
             } else { // new tag:
-                Set<Note> notes = new HashSet<>();
+                LinkedHashSet<Note> notes = new LinkedHashSet<>();
                 notes.add(note);
                 tagToNotesMap.put(newTag, notes);
             }
         }
         // update the tags set for the note:
-        Set<Tag> currentTags = noteToTagsMap.getOrDefault(note, new HashSet<>());
+        LinkedHashSet<Tag> currentTags = noteToTagsMap.getOrDefault(note, new LinkedHashSet<>());
         currentTags.addAll(newTags);
         noteToTagsMap.put(note, currentTags);
         noteSet.add(note);

--- a/src/main/java/seedu/address/storage/JsonAdaptedClient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedClient.java
@@ -74,7 +74,7 @@ class JsonAdaptedClient {
         timezone = source.getTimezone().toString();
         contractExpiryDate = source.getContractExpiryDate().value;
         lastModifiedInstant = source.getLastModifiedInstant().toString();
-        clientNotes.addAll(source.getClientNotes().stream().map(JsonAdaptedNote::new).collect(Collectors.toSet()));
+        clientNotes.addAll(source.getClientNotesAsUnmodifiableList().stream().map(JsonAdaptedNote::new).collect(Collectors.toSet()));
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedClient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedClient.java
@@ -1,9 +1,8 @@
 package seedu.address.storage;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -85,7 +84,7 @@ class JsonAdaptedClient {
      * @throws IllegalValueException if there were any data constraints violated in the adapted client.
      */
     public Client toModelType() throws IllegalValueException {
-        final Set<Note> clientNotes = new HashSet<>();
+        final LinkedHashSet<Note> clientNotes = new LinkedHashSet<>();
         for (JsonAdaptedNote note : this.clientNotes) {
             clientNotes.add(note.toModelType());
         }

--- a/src/main/java/seedu/address/storage/JsonAdaptedClient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedClient.java
@@ -1,7 +1,6 @@
 package seedu.address.storage;
 
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -84,7 +83,7 @@ class JsonAdaptedClient {
      * @throws IllegalValueException if there were any data constraints violated in the adapted client.
      */
     public Client toModelType() throws IllegalValueException {
-        final LinkedHashSet<Note> clientNotes = new LinkedHashSet<>();
+        final List<Note> clientNotes = new ArrayList<>();
         for (JsonAdaptedNote note : this.clientNotes) {
             clientNotes.add(note.toModelType());
         }

--- a/src/main/java/seedu/address/storage/JsonAdaptedClient.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedClient.java
@@ -74,7 +74,8 @@ class JsonAdaptedClient {
         timezone = source.getTimezone().toString();
         contractExpiryDate = source.getContractExpiryDate().value;
         lastModifiedInstant = source.getLastModifiedInstant().toString();
-        clientNotes.addAll(source.getClientNotesAsUnmodifiableList().stream().map(JsonAdaptedNote::new).collect(Collectors.toSet()));
+        clientNotes.addAll(source.getClientNotesAsUnmodifiableList().stream().map(JsonAdaptedNote::new)
+                .collect(Collectors.toSet()));
     }
 
     /**

--- a/src/main/java/seedu/address/ui/WidgetViewBox.java
+++ b/src/main/java/seedu/address/ui/WidgetViewBox.java
@@ -88,9 +88,9 @@ public class WidgetViewBox extends UiPart<Region> {
             }
         }
         name.setText(client.getName().toString());
-        phone.setText("Phone: " + client.getPhone().toString());
-        email.setText("Email: " + client.getEmail().toString());
-        country.setText("Country: " + client.getCountry().getCountryName());
+        phone.setText(client.getPhone().toString());
+        email.setText(client.getEmail().toString());
+        country.setText(client.getCountry().getCountryName());
         contractExpiryDate.setText("Expiry: " + client.getContractExpiryDate().displayValue);
         noteTitle.setText("Notes");
 

--- a/src/main/java/seedu/address/ui/WidgetViewBox.java
+++ b/src/main/java/seedu/address/ui/WidgetViewBox.java
@@ -94,7 +94,7 @@ public class WidgetViewBox extends UiPart<Region> {
         contractExpiryDate.setText("Expiry: " + client.getContractExpiryDate().displayValue);
         noteTitle.setText("Notes");
 
-        Platform.runLater(() -> updateClientNotesDisplay(client.getClientNotesAsList()));
+        Platform.runLater(() -> updateClientNotesDisplay(client.getClientNotesAsUnmodifiableList()));
         drawPaneBorder();
     }
 

--- a/src/main/java/seedu/address/ui/WidgetViewBox.java
+++ b/src/main/java/seedu/address/ui/WidgetViewBox.java
@@ -94,7 +94,7 @@ public class WidgetViewBox extends UiPart<Region> {
         contractExpiryDate.setText("Expiry: " + client.getContractExpiryDate().displayValue);
         noteTitle.setText("Notes");
 
-        Platform.runLater(() -> updateClientNotesDisplay(client.getClientNotes()));
+        Platform.runLater(() -> updateClientNotesDisplay(client.getClientNotesAsList()));
         drawPaneBorder();
     }
 

--- a/src/main/java/seedu/address/ui/WidgetViewBox.java
+++ b/src/main/java/seedu/address/ui/WidgetViewBox.java
@@ -94,7 +94,7 @@ public class WidgetViewBox extends UiPart<Region> {
         contractExpiryDate.setText("Expiry: " + client.getContractExpiryDate().displayValue);
         noteTitle.setText("Notes");
 
-        Platform.runLater(() -> updateClientNotesDisplay(client.getClientNotesAsList()));
+        Platform.runLater(() -> updateClientNotesDisplay(client.getClientNotes()));
         drawPaneBorder();
     }
 

--- a/src/main/java/seedu/address/ui/WidgetViewBox.java
+++ b/src/main/java/seedu/address/ui/WidgetViewBox.java
@@ -88,9 +88,9 @@ public class WidgetViewBox extends UiPart<Region> {
             }
         }
         name.setText(client.getName().toString());
-        phone.setText(client.getPhone().toString());
-        email.setText(client.getEmail().toString());
-        country.setText(client.getCountry().getCountryName());
+        phone.setText("Phone: " + client.getPhone().toString());
+        email.setText("Email: " + client.getEmail().toString());
+        country.setText("Country: " + client.getCountry().getCountryName());
         contractExpiryDate.setText("Expiry: " + client.getContractExpiryDate().displayValue);
         noteTitle.setText("Notes");
 

--- a/src/test/java/seedu/address/logic/commands/ClientNoteEditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClientNoteEditCommandTest.java
@@ -53,9 +53,40 @@ class ClientNoteEditCommandTest {
         ClientNoteEditCommand clientNoteEditCommand = new ClientNoteEditCommand(clientIdx, clientNoteIdx, newEditNote);
         assertCommandSuccess(clientNoteEditCommand, model, expectedResult, expectedModel);
     }
+    // test to show untagged tag removal (in future commit) behaviour is already verified by json file
+    @Test
+    public void execute_editExistingUntaggedNoteToAddTag_discardsDefaultUntaggedTag() {
+        Tag oldTag = Tag.UNTAGGED;
+        Set<Tag> oldTagSet = new HashSet<>();
+        oldTagSet.add(oldTag);
+        Note oldClientNote = new Note(NOTE_CONTENT_1);
+        oldClientNote.setTags(oldTagSet);
 
-    // todo: add test to show untagged tag removal (in future commit) behaviour is verified by json file
+        Tag newTag = new Tag("FreshTag");
+        Set<Tag> newTagSet = new HashSet<>();
+        newTagSet.add(newTag);
+        Note newClientNote = new Note(NOTE_CONTENT_2);
+        newClientNote.setTags(newTagSet);
 
+        Client client = new ClientBuilder().withName("client1").build();
+        model.addClient(client);
+        model.addClientNote(client, oldClientNote);
+
+        Model expectedModel = new ModelManager();
+        Client clientCopy = new ClientBuilder().withName("client1").build();
+        expectedModel.addClient(clientCopy);
+        expectedModel.addClientNote(clientCopy, newClientNote);
+
+        Index clientIdx = Index.fromOneBased(1);
+        Index clientNoteIdx = Index.fromOneBased(1);
+        CommandResult expectedResult = new CommandResult(ClientNoteEditCommand.MESSAGE_EDIT_CLIENT_NOTE_SUCCESS);
+        ClientNoteEditCommand clientNoteEditCommand = new ClientNoteEditCommand(clientIdx,
+                clientNoteIdx, newClientNote);
+        assertCommandSuccess(clientNoteEditCommand, model, expectedResult, expectedModel);
+        assert model.hasClientNote(client, newClientNote);
+        Note resultNote = model.getSortedFilteredClientNotesList().get(0);
+        assertFalse(resultNote.getTags().contains(Tag.UNTAGGED)); // default tag has been removed successfully
+    }
 
     @Test
     public void execute_validClientIdxValidNoteIdxNewTaggedNote_preservesTagHistory() {
@@ -63,12 +94,12 @@ class ClientNoteEditCommandTest {
         Tag newTag = new Tag("newTag");
         Set<Tag> newTagSet = new HashSet<>();
         newTagSet.add(newTag);
-        Set<Tag> tagHistory = new HashSet<>();
-        tagHistory.add(oldTag);
-        Set<Tag> expectedTags = new HashSet<>(tagHistory); // expected to preserve old tags and have new tags
+        Set<Tag> oldTagSet = new HashSet<>();
+        oldTagSet.add(oldTag);
+        Set<Tag> expectedTags = new HashSet<>(oldTagSet); // expected to preserve old tags and have new tags
         expectedTags.add(newTag);
         Note oldClientNote = new Note(NOTE_CONTENT_1);
-        oldClientNote.setTags(tagHistory);
+        oldClientNote.setTags(oldTagSet);
         Note clientNote2 = new Note(NOTE_CONTENT_2);
         Note newClientNote = new Note("dummy note to edit previous note");
         newClientNote.setTags(newTagSet);

--- a/src/test/java/seedu/address/logic/commands/ClientNoteEditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClientNoteEditCommandTest.java
@@ -53,7 +53,7 @@ class ClientNoteEditCommandTest {
         ClientNoteEditCommand clientNoteEditCommand = new ClientNoteEditCommand(clientIdx, clientNoteIdx, newEditNote);
         assertCommandSuccess(clientNoteEditCommand, model, expectedResult, expectedModel);
     }
-    // test to show untagged tag removal (in future commit) behaviour is already verified by json file
+
     @Test
     public void execute_editExistingUntaggedNoteToAddTag_discardsDefaultUntaggedTag() {
         Tag oldTag = Tag.UNTAGGED;

--- a/src/test/java/seedu/address/logic/commands/ClientNoteEditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClientNoteEditCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.ClientNoteEditCommand.MESSAGE_EDIT_CLIENT_NOTE_SUCCESS;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TestUtil.basicEqualsTests;
 
@@ -49,7 +50,8 @@ class ClientNoteEditCommandTest {
         expectedModel.addClientNote(client1Copy, newEditNote);
         expectedModel.addClientNote(client1Copy, clientNote2);
 
-        CommandResult expectedResult = new CommandResult(ClientNoteEditCommand.MESSAGE_EDIT_CLIENT_NOTE_SUCCESS);
+        CommandResult expectedResult = new CommandResult(String.format(MESSAGE_EDIT_CLIENT_NOTE_SUCCESS,
+                client1.getName(), clientNote1, newEditNote));
         ClientNoteEditCommand clientNoteEditCommand = new ClientNoteEditCommand(clientIdx, clientNoteIdx, newEditNote);
         assertCommandSuccess(clientNoteEditCommand, model, expectedResult, expectedModel);
     }
@@ -79,7 +81,8 @@ class ClientNoteEditCommandTest {
 
         Index clientIdx = Index.fromOneBased(1);
         Index clientNoteIdx = Index.fromOneBased(1);
-        CommandResult expectedResult = new CommandResult(ClientNoteEditCommand.MESSAGE_EDIT_CLIENT_NOTE_SUCCESS);
+        CommandResult expectedResult = new CommandResult(String.format(MESSAGE_EDIT_CLIENT_NOTE_SUCCESS,
+                client.getName(), oldClientNote, newClientNote));
         ClientNoteEditCommand clientNoteEditCommand = new ClientNoteEditCommand(clientIdx,
                 clientNoteIdx, newClientNote);
         assertCommandSuccess(clientNoteEditCommand, model, expectedResult, expectedModel);
@@ -116,7 +119,8 @@ class ClientNoteEditCommandTest {
 
         Index clientIdx = Index.fromOneBased(1);
         Index clientNoteIdx = Index.fromOneBased(1);
-        CommandResult expectedResult = new CommandResult(ClientNoteEditCommand.MESSAGE_EDIT_CLIENT_NOTE_SUCCESS);
+        CommandResult expectedResult = new CommandResult(String.format(MESSAGE_EDIT_CLIENT_NOTE_SUCCESS,
+                client1.getName(), oldClientNote, newClientNote));
         ClientNoteEditCommand clientNoteEditCommand = new ClientNoteEditCommand(clientIdx,
                 clientNoteIdx, newClientNote);
         assertCommandSuccess(clientNoteEditCommand, model, expectedResult, expectedModel);

--- a/src/test/java/seedu/address/model/client/ClientTest.java
+++ b/src/test/java/seedu/address/model/client/ClientTest.java
@@ -160,7 +160,7 @@ public class ClientTest {
     public void getClientNotesAsList_modifyUnmodifiableList_throwsException() {
         Client client = new ClientBuilder(ALICE).build();
         client.addClientNote(new Note("hell yes"));
-        List<Note> currentNotes = client.getClientNotesAsList();
+        List<Note> currentNotes = client.getClientNotes();
         assertThrows(UnsupportedOperationException.class, () -> currentNotes.add(new Note("nice lahh")));
     }
 

--- a/src/test/java/seedu/address/model/client/ClientTest.java
+++ b/src/test/java/seedu/address/model/client/ClientTest.java
@@ -178,15 +178,13 @@ public class ClientTest {
     @Test
     public void editClientNote_editExistingNote_noteIsEditedWithoutException() {
         Client client = new ClientBuilder(ALICE).build();
-        Note clientNote = new Note("hell yes");
+        Note oldNote = new Note("hell yes");
         Note newNote = new Note("this be a new note");
-        client.addClientNote(clientNote);
-        assertTrue(client.hasClientNote(clientNote));
+        client.addClientNote(oldNote);
+        assertTrue(client.hasClientNote(oldNote));
         assertFalse(client.hasClientNote(newNote));
-        assertDoesNotThrow(() -> client.editClientNote(clientNote, newNote));
-        client.editClientNote(clientNote, newNote);
-        assertFalse(client.hasClientNote(clientNote));
-        assertTrue(client.hasClientNote(newNote));
+        assertDoesNotThrow(() -> client.editClientNote(oldNote, newNote));
+        assertFalse(client.hasClientNote(oldNote));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/client/ClientTest.java
+++ b/src/test/java/seedu/address/model/client/ClientTest.java
@@ -152,7 +152,7 @@ public class ClientTest {
         Note clientNote = new Note("hell yes");
         client.addClientNote(clientNote);
         assertTrue(client.hasClientNote(clientNote));
-        List<Note> currentNotes = client.getClientNotes();
+        List<Note> currentNotes = client.getClientNotesAsUnmodifiableList();
         assertThrows(UnsupportedOperationException.class, () -> currentNotes.add(new Note("nice lahh")));
     }
 
@@ -160,7 +160,7 @@ public class ClientTest {
     public void getClientNotesAsList_modifyUnmodifiableList_throwsException() {
         Client client = new ClientBuilder(ALICE).build();
         client.addClientNote(new Note("hell yes"));
-        List<Note> currentNotes = client.getClientNotesAsList();
+        List<Note> currentNotes = client.getClientNotesAsUnmodifiableList();
         assertThrows(UnsupportedOperationException.class, () -> currentNotes.add(new Note("nice lahh")));
     }
 

--- a/src/test/java/seedu/address/model/client/ClientTest.java
+++ b/src/test/java/seedu/address/model/client/ClientTest.java
@@ -18,7 +18,6 @@ import static seedu.address.testutil.TypicalClients.ALICE;
 import static seedu.address.testutil.TypicalClients.BOB;
 
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -153,7 +152,7 @@ public class ClientTest {
         Note clientNote = new Note("hell yes");
         client.addClientNote(clientNote);
         assertTrue(client.hasClientNote(clientNote));
-        Set<Note> currentNotes = client.getClientNotes();
+        List<Note> currentNotes = client.getClientNotes();
         assertThrows(UnsupportedOperationException.class, () -> currentNotes.add(new Note("nice lahh")));
     }
 

--- a/src/test/java/seedu/address/model/client/ClientTest.java
+++ b/src/test/java/seedu/address/model/client/ClientTest.java
@@ -160,7 +160,7 @@ public class ClientTest {
     public void getClientNotesAsList_modifyUnmodifiableList_throwsException() {
         Client client = new ClientBuilder(ALICE).build();
         client.addClientNote(new Note("hell yes"));
-        List<Note> currentNotes = client.getClientNotes();
+        List<Note> currentNotes = client.getClientNotesAsList();
         assertThrows(UnsupportedOperationException.class, () -> currentNotes.add(new Note("nice lahh")));
     }
 

--- a/src/test/java/seedu/address/model/note/TagNoteMapTest.java
+++ b/src/test/java/seedu/address/model/note/TagNoteMapTest.java
@@ -83,7 +83,7 @@ class TagNoteMapTest {
     @Test
     public void deleteNote_deleteSoleNoteWithSoleTag_clearsTagToNotesMapAndUniqueTagEntriesReturnsTrue() {
         TAGGED_NOTE.setTags(tags);
-        List<Note> expectedNotesSet = new LinkedList<>();
+        List<Note> expectedNotesSet = new ArrayList<>();
         expectedNotesSet.add(TAGGED_NOTE);
         client.addClientNote(TAGGED_NOTE);
         List<Client> clients = new ArrayList<>();

--- a/src/test/java/seedu/address/model/note/TagNoteMapTest.java
+++ b/src/test/java/seedu/address/model/note/TagNoteMapTest.java
@@ -9,7 +9,6 @@ import static seedu.address.testutil.TypicalClients.ALICE;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -103,7 +102,7 @@ class TagNoteMapTest {
         Tag newTag = new Tag("unprecedentedTag");
         newTagSet.add(newTag);
         newNote.setTags(newTagSet);
-        List<Note> expectedNotesList = new LinkedList<>();
+        List<Note> expectedNotesList = new ArrayList<>();
         expectedNotesList.add(newNote);
         client.addClientNote(TAGGED_NOTE);
         List<Client> clients = new ArrayList<>();

--- a/src/test/java/seedu/address/model/note/TagNoteMapTest.java
+++ b/src/test/java/seedu/address/model/note/TagNoteMapTest.java
@@ -9,6 +9,7 @@ import static seedu.address.testutil.TypicalClients.ALICE;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
@@ -47,12 +48,12 @@ class TagNoteMapTest {
 
     @Test
     public void initTagNoteMapFromCountryNotes_validSetOfTaggedCountryNotes_doesNotThrowException() {
-        Set<Note> inputSet = new HashSet<>();
+        List<Note> inputList = new ArrayList<>();
         Tag tag = new Tag("tagName");
         Note countryNote1 = new Note("this country note will be tagged");
         countryNote1.setTags(tags);
-        inputSet.add(countryNote1);
-        assertDoesNotThrow(() -> this.tagNoteMap.initTagNoteMapFromCountryNotes(inputSet));
+        inputList.add(countryNote1);
+        assertDoesNotThrow(() -> this.tagNoteMap.initTagNoteMapFromCountryNotes(inputList));
     }
 
     @Test
@@ -62,7 +63,7 @@ class TagNoteMapTest {
         List<Client> clients = new ArrayList<>();
         clients.add(client);
         tagNoteMap.initTagNoteMapFromClients(clients);
-        Set<Note> expectedNotes = new HashSet<>();
+        List<Note> expectedNotes = new ArrayList<>();
         expectedNotes.add(TAGGED_NOTE);
         assertEquals(tagNoteMap.getNotesForTag(TEST_TAG), expectedNotes);
     }
@@ -82,7 +83,7 @@ class TagNoteMapTest {
     @Test
     public void deleteNote_deleteSoleNoteWithSoleTag_clearsTagToNotesMapAndUniqueTagEntriesReturnsTrue() {
         TAGGED_NOTE.setTags(tags);
-        Set<Note> expectedNotesSet = new HashSet<>();
+        List<Note> expectedNotesSet = new LinkedList<>();
         expectedNotesSet.add(TAGGED_NOTE);
         client.addClientNote(TAGGED_NOTE);
         List<Client> clients = new ArrayList<>();
@@ -102,16 +103,16 @@ class TagNoteMapTest {
         Tag newTag = new Tag("unprecedentedTag");
         newTagSet.add(newTag);
         newNote.setTags(newTagSet);
-        Set<Note> expectedNotesSet = new HashSet<>();
-        expectedNotesSet.add(newNote);
+        List<Note> expectedNotesList = new LinkedList<>();
+        expectedNotesList.add(newNote);
         client.addClientNote(TAGGED_NOTE);
         List<Client> clients = new ArrayList<>();
         clients.add(client);
         tagNoteMap.initTagNoteMapFromClients(clients);
         assertTrue(tagNoteMap.getTagsForNote(TAGGED_NOTE).equals(tags));
         tagNoteMap.editNote(TAGGED_NOTE, newNote);
-        assertFalse(tagNoteMap.getNotesForTag(TEST_TAG).equals(expectedNotesSet));
-        assertTrue(tagNoteMap.getNotesForTag(newTag).equals(expectedNotesSet));
+        assertFalse(tagNoteMap.getNotesForTag(TEST_TAG).equals(expectedNotesList));
+        assertTrue(tagNoteMap.getNotesForTag(newTag).equals(expectedNotesList));
     }
 
     @Test

--- a/src/test/java/seedu/address/ui/MainWindowTest.java
+++ b/src/test/java/seedu/address/ui/MainWindowTest.java
@@ -116,7 +116,7 @@ public class MainWindowTest extends GuiUnitTest {
 
         terminal.inputCommand("client view 1");
         String resultMessage3 = getResultMessage();
-        String expectedMessage3 = String.format(MESSAGE_VIEW_CLIENT_SUCCESS, "Lim");
+        String expectedMessage3 = String.format(MESSAGE_VIEW_CLIENT_SUCCESS, "Jim");
         assertEquals(expectedMessage3, resultMessage3);
 
         // viewing clients


### PR DESCRIPTION
## Description

Changed notes from being part of Sets to being part of lists.
The note kept getting popped to the bottom of the list because editing used to be implemented as a removal of a target note  and an insertion of its edited form. 

Also added the test `ClientNoteEditCommandTest#execute_editExistingUntaggedNoteToAddTag_discardsDefaultUntaggedTag()` and found a flaw in TagNoteMap initialisation and fixed that.

GUI has been updated too.

Fixes #270 Fixes #296 

## Testing

NIL


## Remarks

NIL