### PR TITLE
Country note delete and country note edit fix

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -25,6 +25,11 @@ public interface Logic {
     CommandResult execute(String commandText) throws CommandException, ParseException;
 
     /**
+     * Sets the boolean that corresponds to whether the country notes list panel is currently visible.
+     */
+    void setCountryNotesListPanelIsVisible(boolean isVisible);
+
+    /**
      * Returns the TbmManager.
      *
      * @see seedu.address.model.Model#getTbmManager()

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -60,6 +60,11 @@ public class LogicManager implements Logic {
     }
 
     @Override
+    public void setCountryNotesListPanelIsVisible(boolean isVisible) {
+        model.setCountryNotesListPanelIsVisible(isVisible);
+    }
+
+    @Override
     public ReadOnlyTbmManager getTbmManager() {
         return model.getTbmManager();
     }

--- a/src/main/java/seedu/address/logic/commands/ClientNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClientNoteEditCommand.java
@@ -43,7 +43,7 @@ public class ClientNoteEditCommand extends Command {
      * @param newNote The newly edited note.
      */
     public ClientNoteEditCommand(Index targetClientIndex, Index targetClientNoteIndex, Note newNote) {
-        requireAllNonNull(targetClientIndex, targetClientNoteIndex);
+        requireAllNonNull(targetClientIndex, targetClientNoteIndex, newNote);
         this.targetClientIndex = targetClientIndex;
         this.targetClientNoteIndex = targetClientNoteIndex;
         this.newNote = newNote;

--- a/src/main/java/seedu/address/logic/commands/CountryNoteDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteDeleteCommand.java
@@ -9,7 +9,6 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.note.CountryNote;
-import seedu.address.ui.WidgetViewOption;
 
 /**
  * A class that encapsulates the logic for deleting country notes.
@@ -52,9 +51,7 @@ public class CountryNoteDeleteCommand extends Command {
 
         CountryNote countryNoteToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteCountryNote(countryNoteToDelete);
-        return new CommandResult(
-                String.format(MESSAGE_SUCCESS, targetIndex.getOneBased(), countryNoteToDelete), false,
-                false, false, WidgetViewOption.generateNullWidgetOption());
+        return new CommandResult(String.format(MESSAGE_SUCCESS, targetIndex.getOneBased(), countryNoteToDelete));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CountryNoteDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteDeleteCommand.java
@@ -18,10 +18,13 @@ public class CountryNoteDeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "country note delete";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the country note at the given index in the last viewed country note list panel.\n"
+            + ": Deletes the country note at the given index in the currently viewed country note list panel.\n"
             + "Parameters: INDEX\n"
             + "Example: " + COMMAND_WORD + " 1";
     public static final String MESSAGE_SUCCESS = "Deleted country note at index %1$s: %2$s";
+    public static final String MESSAGE_COUNTRY_NOTES_NOT_VISIBLE = "Country notes are not currently being displayed,"
+            + " thus this command will not be executed so as to prevent accidental deletion of country notes.\n"
+            + "Please use the " + CountryNoteViewCommand.COMMAND_WORD + " command before using this command.";
     private final Index targetIndex;
 
     /**
@@ -41,6 +44,10 @@ public class CountryNoteDeleteCommand extends Command {
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_COUNTRY_NOTE_DISPLAYED_INDEX);
+        }
+
+        if (!model.getCountryNotesListPanelIsVisible()) {
+            throw new CommandException(MESSAGE_COUNTRY_NOTES_NOT_VISIBLE);
         }
 
         CountryNote countryNoteToDelete = lastShownList.get(targetIndex.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
@@ -31,6 +31,9 @@ public class CountryNoteEditCommand extends Command {
             + " (" + PREFIX_TAG + "TAG)...\n"
             + "Example: " + COMMAND_WORD + " 1 " + PREFIX_NOTE + "better government stability in recent months";
     public static final String MESSAGE_SUCCESS = "Edited country note at index %1$s: %2$s";
+    public static final String MESSAGE_COUNTRY_NOTES_NOT_VISIBLE = "Country notes are not currently being displayed,"
+            + " thus this command will not be executed so as to prevent accidental modification of country notes.\n"
+            + "Please use the " + CountryNoteViewCommand.COMMAND_WORD + " command before using this command.";
     private final Index targetIndex;
     private final CountryNote countryNote;
     private final Set<Tag> tags;
@@ -68,6 +71,10 @@ public class CountryNoteEditCommand extends Command {
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_COUNTRY_NOTE_DISPLAYED_INDEX);
+        }
+
+        if (!model.getCountryNotesListPanelIsVisible()) {
+            throw new CommandException(MESSAGE_COUNTRY_NOTES_NOT_VISIBLE);
         }
 
         CountryNote countryNoteToEdit = lastShownList.get(targetIndex.getZeroBased());

--- a/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
@@ -16,7 +16,6 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.note.CountryNote;
 import seedu.address.model.tag.Tag;
-import seedu.address.ui.WidgetViewOption;
 
 /**
  * A class that encapsulates the logic for editing country notes.
@@ -93,9 +92,7 @@ public class CountryNoteEditCommand extends Command {
 
         model.setCountryNote(countryNoteToEdit, newCountryNote);
 
-        return new CommandResult(
-                String.format(MESSAGE_SUCCESS, targetIndex.getOneBased(), newCountryNote), false,
-                false, false, WidgetViewOption.generateNullWidgetOption());
+        return new CommandResult(String.format(MESSAGE_SUCCESS, targetIndex.getOneBased(), newCountryNote));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CountryNoteEditCommand.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.commons.core.Messages;
@@ -113,8 +112,4 @@ public class CountryNoteEditCommand extends Command {
         return targetIndex.equals(c.targetIndex) && countryNote.equals(c.countryNote) && tags.equals(c.tags);
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(targetIndex, countryNote, tags);
-    }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -204,4 +204,14 @@ public interface Model {
      * @param note    The note to associate the tag with.
      */
     void updateTagNoteMapWithNote(Set<Tag> newTags, Note note);
+
+    /**
+     * Sets the boolean that corresponds to whether the country notes list panel is currently visible.
+     */
+    void setCountryNotesListPanelIsVisible(boolean isVisible);
+
+    /**
+     * Returns true if the country notes list panel is currently visible, false otherwise.
+     */
+    boolean getCountryNotesListPanelIsVisible();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -41,6 +41,8 @@ public class ModelManager implements Model {
     private final WidgetModel widget;
     private final TagNoteMap tagNoteMap;
 
+    private boolean countryNotesListPanelIsVisible = false;
+
     /**
      * Initializes a ModelManager with the given tbmManager and userPrefs.
      */
@@ -273,6 +275,16 @@ public class ModelManager implements Model {
     public void updateFilteredCountryNoteList(Predicate<CountryNote> predicate) {
         requireNonNull(predicate);
         filteredCountryNotes.setPredicate(predicate);
+    }
+
+    @Override
+    public void setCountryNotesListPanelIsVisible(boolean isVisible) {
+        countryNotesListPanelIsVisible = isVisible;
+    }
+
+    @Override
+    public boolean getCountryNotesListPanelIsVisible() {
+        return countryNotesListPanelIsVisible;
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -209,6 +209,9 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
+            logic.setCountryNotesListPanelIsVisible(widgetPlaceholder.getChildren()
+                    .contains(countryNoteListPanel.getRoot()));
+
             return commandResult;
         } catch (CommandException | ParseException e) {
             logger.info("Invalid command: " + commandText);

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,7 +1,9 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
@@ -79,6 +81,17 @@ public class LogicManagerTest {
         assertNotEquals(logic.getGuiSettings(), guiSettings);
         logic.setGuiSettings(guiSettings);
         assertEquals(logic.getGuiSettings(), guiSettings);
+    }
+
+    @Test
+    public void setCountryNotesListPanelIsVisible_propagatesToModel() {
+        // default value
+        assertFalse(model.getCountryNotesListPanelIsVisible());
+
+        logic.setCountryNotesListPanelIsVisible(true);
+        assertTrue(model.getCountryNotesListPanelIsVisible());
+        logic.setCountryNotesListPanelIsVisible(false);
+        assertFalse(model.getCountryNotesListPanelIsVisible());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ClientAddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClientAddCommandTest.java
@@ -115,6 +115,16 @@ public class ClientAddCommandTest {
         }
 
         @Override
+        public void setCountryNotesListPanelIsVisible(boolean isVisible) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean getCountryNotesListPanelIsVisible() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ReadOnlyUserPrefs getUserPrefs() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/ClientNoteDeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClientNoteDeleteCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,6 +34,25 @@ class ClientNoteDeleteCommandTest {
     }
 
     @Test
+    public void constructor_nulls_throwsNullPointerException() {
+        Index clientIdx = Index.fromOneBased(1);
+        Index clientNoteIdx = Index.fromOneBased(1);
+        // make sure args are valid before testing
+        assertDoesNotThrow(() -> new ClientNoteDeleteCommand(clientIdx, clientNoteIdx));
+        // change args to null one by one
+        assertThrows(NullPointerException.class, () -> new ClientNoteDeleteCommand(null, clientNoteIdx));
+        assertThrows(NullPointerException.class, () -> new ClientNoteDeleteCommand(clientIdx, null));
+    }
+
+    @Test
+    public void execute_nullModel_throwsNullPointerException() {
+        Index clientIdx = Index.fromOneBased(1);
+        Index clientNoteIdx = Index.fromOneBased(1);
+        ClientNoteDeleteCommand clientNoteDeleteCommand = new ClientNoteDeleteCommand(clientIdx, clientNoteIdx);
+        assertThrows(NullPointerException.class, () -> clientNoteDeleteCommand.execute(null));
+    }
+
+    @Test
     public void execute_validClientIdxValidNoteIdx_generatesClientNoteDeleteCommandSuccessfully() {
         Index client2Idx = Index.fromOneBased(2);
         Index clientNoteIdx = Index.fromOneBased(1);
@@ -57,7 +77,6 @@ class ClientNoteDeleteCommandTest {
         ClientNoteDeleteCommand clientNoteDeleteCommand = new ClientNoteDeleteCommand(client2Idx, clientNoteIdx);
         assertCommandSuccess(clientNoteDeleteCommand, newModel, expectedResult, expectedModel);
     }
-
 
     @Test
     public void execute_invalidClientIndex_throwsCommandException() {

--- a/src/test/java/seedu/address/logic/commands/ClientNoteEditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClientNoteEditCommandTest.java
@@ -1,9 +1,11 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.ClientNoteEditCommand.MESSAGE_EDIT_CLIENT_NOTE_SUCCESS;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TestUtil.basicEqualsTests;
 
 import java.util.HashSet;
@@ -30,6 +32,28 @@ class ClientNoteEditCommandTest {
     @BeforeEach
     public void setUp() {
         model = new ModelManager();
+    }
+
+    @Test
+    public void constructor_nulls_throwsNullPointerException() {
+        Index clientIdx = Index.fromOneBased(1);
+        Index clientNoteIdx = Index.fromOneBased(1);
+        Note clientNote = new Note(NOTE_CONTENT_1);
+        // make sure all args are valid before doing negative tests
+        assertDoesNotThrow(() -> new ClientNoteEditCommand(clientIdx, clientNoteIdx, clientNote));
+        // change args to null one by one
+        assertThrows(NullPointerException.class, () -> new ClientNoteEditCommand(null, clientNoteIdx, clientNote));
+        assertThrows(NullPointerException.class, () -> new ClientNoteEditCommand(clientIdx, null, clientNote));
+        assertThrows(NullPointerException.class, () -> new ClientNoteEditCommand(clientIdx, clientNoteIdx, null));
+    }
+
+    @Test
+    public void execute_nullModel_throwsNullPointerException() {
+        Index clientIdx = Index.fromOneBased(1);
+        Index clientNoteIdx = Index.fromOneBased(1);
+        Note clientNote = new Note(NOTE_CONTENT_1);
+        ClientNoteEditCommand clientNoteEditCommand = new ClientNoteEditCommand(clientIdx, clientNoteIdx, clientNote);
+        assertThrows(NullPointerException.class, () -> clientNoteEditCommand.execute(null));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CountryNoteDeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CountryNoteDeleteCommandTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TestUtil.basicEqualsTests;
 import static seedu.address.testutil.TypicalClients.getTypicalTbmManager;
@@ -10,8 +11,8 @@ import static seedu.address.testutil.TypicalClients.getTypicalTbmManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -26,6 +27,7 @@ public class CountryNoteDeleteCommandTest {
     @BeforeEach
     public void setUp() {
         model = new ModelManager(getTypicalTbmManager(), new UserPrefs());
+        model.setCountryNotesListPanelIsVisible(true);
     }
 
     @Test
@@ -57,7 +59,7 @@ public class CountryNoteDeleteCommandTest {
         Index invalidCountryNoteIndex = Index.fromOneBased(model.getSortedFilteredCountryNoteList().size() + 1);
         CountryNoteDeleteCommand countryNoteDeleteCommand =
                 new CountryNoteDeleteCommand(invalidCountryNoteIndex);
-        assertThrows(CommandException.class, () -> countryNoteDeleteCommand.execute(model));
+        assertCommandFailure(countryNoteDeleteCommand, model, Messages.MESSAGE_INVALID_COUNTRY_NOTE_DISPLAYED_INDEX);
     }
 
     @Test
@@ -77,6 +79,16 @@ public class CountryNoteDeleteCommandTest {
                 genericCountryNote);
 
         assertCommandSuccess(countryNoteDeleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_countryNotesPanelNotVisible_throwsCommandException() {
+        model.setCountryNotesListPanelIsVisible(false);
+        model.addCountryNote(genericCountryNote);
+        Index index = Index.fromOneBased(1);
+        CountryNoteDeleteCommand countryNoteDeleteCommand = new CountryNoteDeleteCommand(index);
+        assertCommandFailure(countryNoteDeleteCommand, model,
+                CountryNoteDeleteCommand.MESSAGE_COUNTRY_NOTES_NOT_VISIBLE);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/CountryNoteEditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CountryNoteEditCommandTest.java
@@ -2,49 +2,77 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TestUtil.basicEqualsTests;
+import static seedu.address.testutil.TypicalClients.getTypicalTbmManager;
 
 import java.util.HashSet;
 import java.util.Set;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 import seedu.address.model.country.Country;
 import seedu.address.model.note.CountryNote;
 import seedu.address.model.tag.Tag;
 
 public class CountryNoteEditCommandTest {
+
+    private final Index index = Index.fromOneBased(1);
+    private final CountryNote countryNote = new CountryNote("abc", new Country("US"));
+    private final CountryNote countryNoteWithDifferentCountry = new CountryNote("abc", new Country("SG"));
+    private final CountryNote countryNoteWithDifferentContent = new CountryNote("abcde", new Country("US"));
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalTbmManager(), new UserPrefs());
+        model.setCountryNotesListPanelIsVisible(true);
+    }
+
+    @Test
+    public void equals_basicTests() {
+        CountryNoteEditCommand countryNoteEditCommand =
+                new CountryNoteEditCommand(index, countryNoteWithDifferentCountry);
+        // basic equals tests
+        basicEqualsTests(countryNoteEditCommand);
+    }
+
     @Test
     public void equals_allEqual_equal() {
-        CountryNoteEditCommand expected = new CountryNoteEditCommand(Index.fromOneBased(1),
-                new CountryNote("abc", Country.NULL_COUNTRY));
-        CountryNoteEditCommand actual = new CountryNoteEditCommand(Index.fromOneBased(1),
-                new CountryNote("abc", Country.NULL_COUNTRY));
+        CountryNoteEditCommand expected = new CountryNoteEditCommand(index, countryNote);
+        CountryNoteEditCommand actual = new CountryNoteEditCommand(index, countryNote);
         assertEquals(expected, actual);
     }
 
     @Test
     public void equals_diffIndex_notEqual() {
-        CountryNoteEditCommand expected = new CountryNoteEditCommand(Index.fromOneBased(1),
-                new CountryNote("abc", Country.NULL_COUNTRY));
-        CountryNoteEditCommand actual = new CountryNoteEditCommand(Index.fromOneBased(2),
-                new CountryNote("abc", Country.NULL_COUNTRY));
+        CountryNoteEditCommand expected = new CountryNoteEditCommand(index, countryNote);
+        CountryNoteEditCommand actual = new CountryNoteEditCommand(Index.fromOneBased(2), countryNote);
         assertNotEquals(expected, actual);
     }
 
     @Test
     public void equals_diffCountryNote_notEqual() {
-        CountryNoteEditCommand expected = new CountryNoteEditCommand(Index.fromOneBased(1),
-                new CountryNote("abcd", Country.NULL_COUNTRY));
-        CountryNoteEditCommand actual = new CountryNoteEditCommand(Index.fromOneBased(1),
-                new CountryNote("abc", Country.NULL_COUNTRY));
+        CountryNoteEditCommand expected = new CountryNoteEditCommand(index, countryNote);
+        CountryNoteEditCommand actual = new CountryNoteEditCommand(index, countryNoteWithDifferentCountry);
+        CountryNoteEditCommand actual2 = new CountryNoteEditCommand(index, countryNoteWithDifferentContent);
         assertNotEquals(expected, actual);
+        assertNotEquals(expected, actual2);
+        assertNotEquals(actual, actual2);
     }
 
     @Test
     public void equals_sameTags_equal() {
-        CountryNoteEditCommand expected = new CountryNoteEditCommand(Index.fromOneBased(1), new HashSet<>());
-        CountryNoteEditCommand actual = new CountryNoteEditCommand(Index.fromOneBased(1), new HashSet<>());
+        CountryNoteEditCommand expected = new CountryNoteEditCommand(index, new HashSet<>());
+        CountryNoteEditCommand actual = new CountryNoteEditCommand(index, new HashSet<>());
         assertEquals(expected, actual);
     }
 
@@ -52,8 +80,48 @@ public class CountryNoteEditCommandTest {
     public void equals_diffTags_equal() {
         Set<Tag> tags = new HashSet<>();
         tags.add(new Tag("a"));
-        CountryNoteEditCommand expected = new CountryNoteEditCommand(Index.fromOneBased(1), tags);
-        CountryNoteEditCommand actual = new CountryNoteEditCommand(Index.fromOneBased(1), new HashSet<>());
+        CountryNoteEditCommand expected = new CountryNoteEditCommand(index, tags);
+        CountryNoteEditCommand actual = new CountryNoteEditCommand(index, new HashSet<>());
         assertNotEquals(expected, actual);
     }
+
+    @Test
+    public void execute_invalidCountryNoteIndex_throwsCommandException() {
+        Index invalidCountryNoteIndex = Index.fromOneBased(model.getSortedFilteredCountryNoteList().size() + 1);
+        CountryNoteEditCommand countryNoteEditCommand =
+                new CountryNoteEditCommand(invalidCountryNoteIndex, countryNote);
+        assertCommandFailure(countryNoteEditCommand, model, Messages.MESSAGE_INVALID_COUNTRY_NOTE_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_nullModel_throwsNullPointerException() {
+        CountryNoteEditCommand countryNoteEditCommand = new CountryNoteEditCommand(index, countryNote);
+        assertThrows(NullPointerException.class, () -> countryNoteEditCommand.execute(null));
+    }
+
+    @Test
+    public void execute_validCountryNoteIndex_successfullyDeletesNote() {
+        model.addCountryNote(countryNote);
+        CountryNoteEditCommand countryNoteEditCommand =
+                new CountryNoteEditCommand(index, countryNoteWithDifferentContent);
+
+        Model expectedModel = new ModelManager(getTypicalTbmManager(), new UserPrefs());
+        expectedModel.addCountryNote(countryNoteWithDifferentContent);
+        String expectedMessage = String.format(CountryNoteEditCommand.MESSAGE_SUCCESS, index.getOneBased(),
+                countryNoteWithDifferentContent);
+
+        assertCommandSuccess(countryNoteEditCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_countryNotesPanelNotVisible_throwsCommandException() {
+        model.setCountryNotesListPanelIsVisible(false);
+        model.addCountryNote(countryNote);
+        CountryNoteEditCommand countryNoteEditCommand =
+                new CountryNoteEditCommand(index, countryNoteWithDifferentContent);
+
+        assertCommandFailure(countryNoteEditCommand, model,
+                CountryNoteEditCommand.MESSAGE_COUNTRY_NOTES_NOT_VISIBLE);
+    }
+
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -285,6 +285,17 @@ public class ModelManagerTest {
         assertEquals(modelManagerCopy.getSortedFilteredClientList().get(0), client2);
     }
 
+    @Test
+    public void countryNotesListPanelIsVisible_setterAndGetter() {
+        // default is false
+        assertFalse(modelManager.getCountryNotesListPanelIsVisible());
+
+        modelManager.setCountryNotesListPanelIsVisible(true);
+        assertTrue(modelManager.getCountryNotesListPanelIsVisible());
+        modelManager.setCountryNotesListPanelIsVisible(false);
+        assertFalse(modelManager.getCountryNotesListPanelIsVisible());
+    }
+
     /* todo future tests:
      *  run coverage for model manager test and see what's missing:
      * 1. setClient


### PR DESCRIPTION
## Description

Refer to bug issue.

Fixes #283

## Testing

Ran all tests, passed.
Also tried deleting/editing country notes from a variety of views, for example default view, and client view, and country view. Works as expected.

## Remarks

NIL
